### PR TITLE
fix: align worker hooks and defaults with tunasync

### DIFF
--- a/crates/hustsync-config-parser/src/lib.rs
+++ b/crates/hustsync-config-parser/src/lib.rs
@@ -183,9 +183,8 @@ pub struct WorkerManagerConfig {
     pub api_base: Option<String>,
     /// List of manager API base URLs for HA deployments. When set and
     /// non-empty, this takes precedence over `api_base`. Write operations
-    /// (register, status push, schedule push) broadcast to all entries
-    /// and stop on the first success; read operations use only the first
-    /// entry.
+    /// (register, status push, schedule push) broadcast to every entry;
+    /// read operations use only the first entry.
     pub api_base_list: Option<Vec<String>>,
     pub token: Option<String>,
     pub ca_cert: Option<String>,

--- a/crates/hustsync-config-parser/src/lib.rs
+++ b/crates/hustsync-config-parser/src/lib.rs
@@ -788,6 +788,18 @@ fn contains_unbracketed_ipv6(upstream: &str) -> bool {
 /// 4. `size_pattern`, when set, must compile and have exactly one capture group.
 /// 5. `stage1_profile`, when set, must be one of the known profiles.
 pub fn validate_worker_config(cfg: &WorkerConfig) -> Result<(), ConfigError> {
+    if cfg
+        .cgroup
+        .as_ref()
+        .and_then(|cgroup| cgroup.enable)
+        .unwrap_or(false)
+    {
+        return Err(ConfigError::UnsupportedField {
+            field: "cgroup.enable".into(),
+            tracked_in: "parity-checklist: Cgroup enforcement parity",
+        });
+    }
+
     let Some(mirrors) = cfg.mirrors.as_deref() else {
         return Ok(());
     };

--- a/crates/hustsync-config-parser/src/lib.rs
+++ b/crates/hustsync-config-parser/src/lib.rs
@@ -86,7 +86,7 @@ impl Default for ManagerServerConfig {
     fn default() -> Self {
         ManagerServerConfig {
             addr: "127.0.0.1".into(),
-            port: 12345,
+            port: 14242,
             ssl_cert: "".into(),
             ssl_key: "".into(),
         }
@@ -194,7 +194,7 @@ pub struct WorkerManagerConfig {
 impl Default for WorkerManagerConfig {
     fn default() -> Self {
         WorkerManagerConfig {
-            api_base: Some("http://localhost:12345".into()),
+            api_base: Some("http://localhost:14242".into()),
             api_base_list: None,
             token: Some("".into()),
             ca_cert: Some("".into()),

--- a/crates/hustsync-config-parser/tests/test_provider_validation.rs
+++ b/crates/hustsync-config-parser/tests/test_provider_validation.rs
@@ -5,7 +5,9 @@
 // illegal input that must produce `ConfigError::InvalidValue`.
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::panic)]
-use hustsync_config_parser::{ConfigError, MirrorConfig, WorkerConfig, validate_worker_config};
+use hustsync_config_parser::{
+    ConfigError, MirrorConfig, WorkerCgroupConfig, WorkerConfig, validate_worker_config,
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -29,6 +31,31 @@ fn named_rsync_mirror(name: &str, upstream: &str) -> MirrorConfig {
         upstream: Some(upstream.into()),
         ..MirrorConfig::default()
     }
+}
+
+#[test]
+fn reject_enabled_cgroup_until_runtime_support_exists() {
+    let mut cfg = worker_with_single_mirror(named_rsync_mirror(
+        "arch",
+        "rsync://mirror.example.org/archlinux/",
+    ));
+    cfg.cgroup = Some(WorkerCgroupConfig {
+        enable: Some(true),
+        base_path: Some("/sys/fs/cgroup".into()),
+        group: Some("hustsync".into()),
+    });
+
+    let err = validate_worker_config(&cfg).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ConfigError::UnsupportedField {
+                ref field,
+                ..
+            } if field == "cgroup.enable"
+        ),
+        "enabled cgroup must be rejected instead of silently ignored, got {err:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hustsync-internal/src/msg.rs
+++ b/crates/hustsync-internal/src/msg.rs
@@ -3,9 +3,18 @@ use std::collections::HashMap;
 use chrono::DateTime;
 use chrono::Utc;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
 
 use crate::status::SyncStatus;
+
+fn null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -61,7 +70,9 @@ pub enum CmdVerb {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct WorkerCmd {
+    #[serde(default, deserialize_with = "null_as_default")]
     pub options: HashMap<String, bool>,
+    #[serde(default, deserialize_with = "null_as_default")]
     pub args: Vec<String>,
     pub mirror_id: String,
     pub cmd: CmdVerb,
@@ -70,9 +81,44 @@ pub struct WorkerCmd {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ClientCmd {
+    #[serde(default, deserialize_with = "null_as_default")]
     pub options: HashMap<String, bool>,
+    #[serde(default, deserialize_with = "null_as_default")]
     pub args: Vec<String>,
     pub mirror_id: String,
     pub worker_id: String,
     pub cmd: CmdVerb,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_cmd_accepts_go_null_args_and_options() {
+        let cmd: WorkerCmd = serde_json::from_str(
+            r#"{"options":null,"args":null,"mirror_id":"archlinux","cmd":"ping"}"#,
+        )
+        .unwrap();
+
+        assert!(cmd.options.is_empty());
+        assert!(cmd.args.is_empty());
+        assert_eq!(cmd.mirror_id, "archlinux");
+        assert_eq!(cmd.cmd, CmdVerb::Ping);
+    }
+
+    #[test]
+    fn client_cmd_accepts_go_null_args_and_options() {
+        let cmd: ClientCmd = serde_json::from_str(
+            r#"{"options":null,"args":null,"worker_id":"w1","mirror_id":"archlinux","cmd":"restart"}"#,
+        )
+        .unwrap();
+
+        assert!(cmd.options.is_empty());
+        assert!(cmd.args.is_empty());
+        assert_eq!(cmd.worker_id, "w1");
+        assert_eq!(cmd.mirror_id, "archlinux");
+        assert_eq!(cmd.cmd, CmdVerb::Restart);
+    }
 }

--- a/crates/hustsync-manager/src/config.rs
+++ b/crates/hustsync-manager/src/config.rs
@@ -5,6 +5,10 @@ use hustsync_config_parser::ManagerConfig;
 use crate::ManagerError;
 
 pub fn load_config(cfg_file: impl AsRef<Path>) -> Result<ManagerConfig, ManagerError> {
+    if cfg_file.as_ref().as_os_str().is_empty() {
+        return Ok(ManagerConfig::default());
+    }
+
     Ok(hustsync_config_parser::parse_config::<ManagerConfig>(
         cfg_file,
     )?)

--- a/crates/hustsync-manager/src/handlers.rs
+++ b/crates/hustsync-manager/src/handlers.rs
@@ -1,8 +1,8 @@
+use axum::Json;
 use axum::extract::{FromRequestParts, Path, State};
 use axum::http::StatusCode;
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use chrono::Utc;
 use hustsync_internal::msg::{
     ClientCmd, CmdVerb, MirrorSchedules, MirrorStatus, WorkerCmd, WorkerStatus,
@@ -10,6 +10,7 @@ use hustsync_internal::msg::{
 use hustsync_internal::status::SyncStatus;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::path::Path as FsPath;
 use std::sync::Arc;
 
 use crate::database::DbAdapterTrait;
@@ -25,6 +26,36 @@ fn ok_json(data: impl Serialize) -> Response {
 
 fn ok_message(msg: &str) -> Response {
     (StatusCode::OK, Json(json!({ INFO_KEY: msg }))).into_response()
+}
+
+fn write_status_file(manager: &Manager, adapter: &dyn DbAdapterTrait) -> Result<(), String> {
+    let status_file = manager.config.files.status_file.trim();
+    if status_file.is_empty() {
+        return Ok(());
+    }
+
+    let statuses = adapter
+        .list_all_mirror_status()
+        .map_err(|e| format!("list all mirror status: {e}"))?;
+    let web_statuses: Vec<hustsync_internal::status_web::WebMirrorStatus> =
+        statuses.into_iter().map(|s| s.into()).collect();
+    let data = serde_json::to_vec(&web_statuses).map_err(|e| format!("serialize status: {e}"))?;
+
+    let expanded = hustsync_internal::util::expand_tilde(status_file);
+    let path = FsPath::new(&expanded);
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create parent directory {}: {e}", parent.display()))?;
+    }
+    std::fs::write(path, data).map_err(|e| format!("write {}: {e}", path.display()))
+}
+
+fn refresh_status_file(manager: &Manager, adapter: &dyn DbAdapterTrait) {
+    if let Err(e) = write_status_file(manager, adapter) {
+        tracing::error!("Failed to refresh status file: {}", e);
+    }
 }
 
 // Custom Extractor for the database adapter
@@ -114,10 +145,7 @@ pub async fn list_jobs_of_worker(
     }
 }
 
-pub async fn delete_worker(
-    Database(adapter): Database,
-    Path(worker_id): Path<String>,
-) -> Response {
+pub async fn delete_worker(Database(adapter): Database, Path(worker_id): Path<String>) -> Response {
     match adapter.delete_worker(&worker_id) {
         Ok(_) => {
             tracing::info!("Worker <{}> deleted", worker_id);
@@ -130,9 +158,15 @@ pub async fn delete_worker(
     }
 }
 
-pub async fn flush_disabled_jobs(Database(adapter): Database) -> Response {
+pub async fn flush_disabled_jobs(
+    State(manager): State<Arc<Manager>>,
+    Database(adapter): Database,
+) -> Response {
     match adapter.flush_disabled_jobs() {
-        Ok(_) => ok_message("flushed"),
+        Ok(_) => {
+            refresh_status_file(&manager, adapter.as_ref());
+            ok_message("flushed")
+        }
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to flush disabled jobs: {}", e),
@@ -141,6 +175,7 @@ pub async fn flush_disabled_jobs(Database(adapter): Database) -> Response {
 }
 
 pub async fn update_job_of_worker(
+    State(manager): State<Arc<Manager>>,
     Database(adapter): Database,
     Path((worker_id, mirror_id)): Path<(String, String)>,
     Json(mut status): Json<MirrorStatus>,
@@ -189,7 +224,10 @@ pub async fn update_job_of_worker(
     }
 
     match adapter.update_mirror_status(&worker_id, &mirror_id, status) {
-        Ok(new_status) => ok_json(new_status),
+        Ok(new_status) => {
+            refresh_status_file(&manager, adapter.as_ref());
+            ok_json(new_status)
+        }
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to update job: {}", e),
@@ -208,6 +246,7 @@ pub struct SizeMsg {
 }
 
 pub async fn update_mirror_size(
+    State(manager): State<Arc<Manager>>,
     Database(adapter): Database,
     Path((worker_id, mirror_id)): Path<(String, String)>,
     Json(msg): Json<SizeMsg>,
@@ -219,7 +258,10 @@ pub async fn update_mirror_size(
             if !msg.size.is_empty() && msg.size != "unknown" {
                 status.size = msg.size;
                 match adapter.update_mirror_status(&worker_id, &mirror_id, status) {
-                    Ok(new_status) => ok_json(new_status),
+                    Ok(new_status) => {
+                        refresh_status_file(&manager, adapter.as_ref());
+                        ok_json(new_status)
+                    }
                     Err(e) => error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         format!("Failed to save size: {}", e),
@@ -237,6 +279,7 @@ pub async fn update_mirror_size(
 }
 
 pub async fn update_schedules_of_worker(
+    State(manager): State<Arc<Manager>>,
     Database(adapter): Database,
     Path(worker_id): Path<String>,
     Json(schedules): Json<MirrorSchedules>,
@@ -275,6 +318,7 @@ pub async fn update_schedules_of_worker(
         }
     }
 
+    refresh_status_file(&manager, adapter.as_ref());
     ok_json(json!({}))
 }
 
@@ -317,25 +361,49 @@ pub async fn handle_cmd(
     {
         let mut new_status = status;
         new_status.status = SyncStatus::Disabled;
-        let _ = adapter.update_mirror_status(worker_id, &client_cmd.mirror_id, new_status);
+        match adapter.update_mirror_status(worker_id, &client_cmd.mirror_id, new_status) {
+            Ok(_) => refresh_status_file(&manager, adapter.as_ref()),
+            Err(e) => tracing::error!("Failed to pre-set disabled status: {}", e),
+        }
     } else if client_cmd.cmd == CmdVerb::Stop
         && let Ok(status) = adapter.get_mirror_status(worker_id, &client_cmd.mirror_id)
     {
         let mut new_status = status;
         new_status.status = SyncStatus::Paused;
-        let _ = adapter.update_mirror_status(worker_id, &client_cmd.mirror_id, new_status);
+        match adapter.update_mirror_status(worker_id, &client_cmd.mirror_id, new_status) {
+            Ok(_) => refresh_status_file(&manager, adapter.as_ref()),
+            Err(e) => tracing::error!("Failed to pre-set paused status: {}", e),
+        }
     }
 
     let Some(ref client) = manager.http_client else {
-        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "HTTP client not initialized");
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "HTTP client not initialized",
+        );
     };
 
     // Workers accept commands at POST / (worker URL ends with "/").
-    // Go forwards any request error (connect refused, timeout, non-2xx) as
-    // 500 with a unified error JSON — no 502/504 discrimination.
+    // Transport errors still collapse to 500 for compatibility with the old
+    // manager path, but worker-side non-2xx responses must not be reported as
+    // a successful command dispatch.
     let url = worker.url.clone();
     match client.post(&url).json(&worker_cmd).send().await {
-        Ok(_) => ok_message(&format!("successfully send command to worker {}", worker_id)),
+        Ok(resp) if resp.status().is_success() => ok_message(&format!(
+            "successfully send command to worker {}",
+            worker_id
+        )),
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            error_response(
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "post command to worker {}({}) returned {}: {}",
+                    worker_id, url, status, body
+                ),
+            )
+        }
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("post command to worker {}({}) fail: {}", worker_id, url, e),

--- a/crates/hustsync-manager/src/handlers.rs
+++ b/crates/hustsync-manager/src/handlers.rs
@@ -309,7 +309,7 @@ pub async fn handle_cmd(
     };
 
     // Pre-forward status bookkeeping: Disable flips the row to Disabled,
-    // Stop flips a non-Disabled row to Paused. Go does the same at
+    // Stop flips the row to Paused, including Disabled rows. Go does the same at
     // `handleClientCmd` around line 450. These are best-effort — do not
     // gate the forward on their outcome.
     if client_cmd.cmd == CmdVerb::Disable
@@ -320,7 +320,6 @@ pub async fn handle_cmd(
         let _ = adapter.update_mirror_status(worker_id, &client_cmd.mirror_id, new_status);
     } else if client_cmd.cmd == CmdVerb::Stop
         && let Ok(status) = adapter.get_mirror_status(worker_id, &client_cmd.mirror_id)
-        && status.status != SyncStatus::Disabled
     {
         let mut new_status = status;
         new_status.status = SyncStatus::Paused;

--- a/crates/hustsync-manager/tests/contract_manager_cmd.rs
+++ b/crates/hustsync-manager/tests/contract_manager_cmd.rs
@@ -13,6 +13,8 @@
 //! 5. Worker unreachable (connection refused) → 500 (Go does not
 //!    discriminate 502; all forward errors collapse to 500).
 //! 6. Worker timeout (accepts but never responds) → 500.
+//! 7. Stop command pre-sets manager-side status to `paused`, even when
+//!    the previous status was `disabled` and forwarding fails.
 //!
 //! Mock worker strategy: `tokio::net::TcpListener` on an ephemeral port —
 //! no new crate dependencies required.
@@ -24,6 +26,7 @@ mod contract;
 use axum::http::Request;
 use axum::{body::Body, http::StatusCode};
 use hustsync_internal::msg::{ClientCmd, CmdVerb, WorkerStatus};
+use serde_json::json;
 use std::collections::HashMap;
 use tokio::io::AsyncWriteExt;
 use tower::ServiceExt;
@@ -63,8 +66,13 @@ async fn register_worker(app: axum::Router, url: &str) -> axum::Router {
 
 /// Build the JSON body for a `POST /cmd` request.
 fn cmd_body(worker_id: &str, mirror_id: &str) -> Vec<u8> {
+    cmd_body_with_verb(worker_id, mirror_id, CmdVerb::Start)
+}
+
+/// Build the JSON body for a `POST /cmd` request with a specific command.
+fn cmd_body_with_verb(worker_id: &str, mirror_id: &str, cmd: CmdVerb) -> Vec<u8> {
     let cmd = ClientCmd {
-        cmd: CmdVerb::Start,
+        cmd,
         worker_id: worker_id.to_string(),
         mirror_id: mirror_id.to_string(),
         args: vec![],
@@ -132,6 +140,98 @@ async fn cmd_happy_path_returns_fixed_message() {
     let got = contract::body_json(resp).await;
     let want = contract::load_fixture("cmd/response_happy.json");
     contract::assert_json_eq_masked(&got, &want, &[]);
+}
+
+/// POST /cmd `stop` pre-sets manager-side job status to `paused`
+/// unconditionally, including rows that were already `disabled`.
+///
+/// Go updates the stored status before forwarding to the worker. The mock
+/// worker URL here is intentionally closed, so the command returns 500 after
+/// the pre-status write; the stored row must still be `paused`.
+#[tokio::test]
+async fn cmd_stop_pre_sets_disabled_job_to_paused_even_when_forward_fails() {
+    let closed_port = {
+        let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let p = l.local_addr().unwrap().port();
+        drop(l);
+        p
+    };
+    let worker_url = format!("http://127.0.0.1:{}/", closed_port);
+
+    let (app, _dir) = contract::spawn_manager();
+    let app = register_worker(app, &worker_url).await;
+
+    let disabled_status = json!({
+    "name": "archlinux",
+    "worker": "mirror-01",
+    "upstream": "rsync://mirror.example/archlinux/",
+    "size": "0",
+    "error_msg": "",
+    "last_update": "1970-01-01T00:00:00Z",
+    "last_started": "1970-01-01T00:00:00Z",
+    "last_ended": "1970-01-01T00:00:00Z",
+    "next_schedule": "1970-01-01T00:00:00Z",
+    "status": "disabled",
+    "is_master": true
+    });
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/workers/mirror-01/jobs/archlinux")
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::to_vec(&disabled_status).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let created = contract::body_json(resp).await;
+    assert_eq!(created["status"], "disabled");
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/cmd")
+                .header("Content-Type", "application/json")
+                .body(Body::from(cmd_body_with_verb(
+                    "mirror-01",
+                    "archlinux",
+                    CmdVerb::Stop,
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "closed worker URL forces the forward-error path after the pre-status write"
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/workers/mirror-01/jobs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let jobs = contract::body_json(resp).await;
+    let job = jobs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|job| job["name"] == "archlinux")
+        .unwrap();
+    assert_eq!(job["status"], "paused");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hustsync-manager/tests/contract_manager_cmd.rs
+++ b/crates/hustsync-manager/tests/contract_manager_cmd.rs
@@ -13,7 +13,8 @@
 //! 5. Worker unreachable (connection refused) → 500 (Go does not
 //!    discriminate 502; all forward errors collapse to 500).
 //! 6. Worker timeout (accepts but never responds) → 500.
-//! 7. Stop command pre-sets manager-side status to `paused`, even when
+//! 7. Worker non-2xx response → manager returns 502 instead of a false success.
+//! 8. Stop command pre-sets manager-side status to `paused`, even when
 //!    the previous status was `disabled` and forwarding fails.
 //!
 //! Mock worker strategy: `tokio::net::TcpListener` on an ephemeral port —
@@ -140,6 +141,52 @@ async fn cmd_happy_path_returns_fixed_message() {
     let got = contract::body_json(resp).await;
     let want = contract::load_fixture("cmd/response_happy.json");
     contract::assert_json_eq_masked(&got, &want, &[]);
+}
+
+/// POST /cmd must not report success when the worker rejects the command.
+///
+/// This deliberately diverges from Go's current TODO path, where `PostJSON`
+/// only checks transport errors. Rust treats a worker-side 4xx/5xx as a failed
+/// forward so CLI users do not see "success" for commands that did not run.
+#[tokio::test]
+async fn cmd_worker_non_success_returns_bad_gateway() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let worker_port = listener.local_addr().unwrap().port();
+    let worker_url = format!("http://127.0.0.1:{}/", worker_port);
+
+    tokio::spawn(async move {
+        use tokio::io::AsyncReadExt;
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = vec![0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+            let body = "{\"msg\":\"Mirror ``missing'' not found\"}";
+            let response = format!(
+                "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+            let _ = stream.shutdown().await;
+        }
+    });
+
+    let (app, _dir) = contract::spawn_manager();
+    let app = register_worker(app, &worker_url).await;
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/cmd")
+        .header("Content-Type", "application/json")
+        .body(Body::from(cmd_body("mirror-01", "missing")))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+    let got = contract::body_json(resp).await;
+    let error = got["error"].as_str().unwrap();
+    assert!(error.contains("returned 404 Not Found"), "{error}");
+    assert!(error.contains("Mirror ``missing'' not found"), "{error}");
 }
 
 /// POST /cmd `stop` pre-sets manager-side job status to `paused`

--- a/crates/hustsync-manager/tests/contract_status_file.rs
+++ b/crates/hustsync-manager/tests/contract_status_file.rs
@@ -1,0 +1,113 @@
+//! Contract tests for manager `files.status_file`.
+//!
+//! The status file is an operator-facing snapshot of `GET /jobs`. It must be
+//! refreshed when manager-side mirror status changes, not just parsed from
+//! config and ignored.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod contract;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use hustsync_config_parser::{ManagerConfig, ManagerFileConfig, ManagerServerConfig};
+use hustsync_manager::Manager;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn spawn_manager_with_status_file() -> (axum::Router, TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let status_path = dir.path().join("status.json");
+
+    let config = Arc::new(ManagerConfig {
+        debug: false,
+        server: ManagerServerConfig {
+            addr: "127.0.0.1".to_string(),
+            port: 0,
+            ssl_cert: String::new(),
+            ssl_key: String::new(),
+        },
+        files: ManagerFileConfig {
+            status_file: status_path.to_string_lossy().into_owned(),
+            db_type: "redb".to_string(),
+            db_file: db_path.to_string_lossy().into_owned(),
+            ca_cert: String::new(),
+        },
+    });
+
+    let manager = Manager::new(config).unwrap();
+    let router = Arc::new(manager).make_router();
+    (router, dir, status_path)
+}
+
+async fn post_json(app: axum::Router, uri: &str, body: Value) -> axum::response::Response {
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn status_file_is_refreshed_after_status_and_size_updates() {
+    let (app, _dir, status_path) = spawn_manager_with_status_file();
+
+    let worker = json!({
+        "id": "status-worker",
+        "url": "http://127.0.0.1:6000/",
+        "token": "secret",
+        "last_online": "2023-01-01T00:00:00Z",
+        "last_register": "2023-01-01T00:00:00Z"
+    });
+    let resp = post_json(app.clone(), "/workers", worker).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let status = json!({
+        "name": "archlinux",
+        "worker": "status-worker",
+        "upstream": "rsync://mirror.example/archlinux/",
+        "size": "unknown",
+        "error_msg": "",
+        "last_update": "2023-01-01T00:00:00Z",
+        "last_started": "2023-01-01T00:00:00Z",
+        "last_ended": "2023-01-01T00:00:00Z",
+        "next_schedule": "2023-01-01T00:00:00Z",
+        "status": "success",
+        "is_master": true
+    });
+    let resp = post_json(app.clone(), "/workers/status-worker/jobs/archlinux", status).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let snapshot: Value =
+        serde_json::from_slice(&std::fs::read(&status_path).expect("status file must exist"))
+            .unwrap();
+    let jobs = snapshot.as_array().unwrap();
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0]["name"], "archlinux");
+    assert_eq!(jobs[0]["status"], "success");
+    assert!(
+        jobs[0].get("last_update_ts").is_some(),
+        "status file must use the same web view shape as GET /jobs"
+    );
+
+    let resp = post_json(
+        app,
+        "/workers/status-worker/jobs/archlinux/size",
+        json!({"size": "42M"}),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let snapshot: Value =
+        serde_json::from_slice(&std::fs::read(&status_path).expect("status file must exist"))
+            .unwrap();
+    assert_eq!(snapshot[0]["size"], "42M");
+}

--- a/crates/hustsync-manager/tests/test_config.rs
+++ b/crates/hustsync-manager/tests/test_config.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use hustsync_config_parser::ManagerConfig;
+use hustsync_manager::load_config;
 use std::fs;
 use std::io::Write;
 #[cfg(unix)]
@@ -32,6 +33,13 @@ fn toml_decoding_should_work() {
     assert_eq!(cfg.server.addr, "0.0.0.0");
     assert_eq!(cfg.server.port, 5000);
     assert_eq!(cfg.files.db_file, "/var/lib/hustsync/hustsync.db");
+}
+
+#[test]
+fn empty_config_path_uses_defaults() {
+    let cfg = load_config("").expect("empty config path should load defaults");
+    assert_eq!(cfg, ManagerConfig::default());
+    assert_eq!(cfg.server.port, 14242);
 }
 
 // TODO 创建 clap 应用以测试更完整的加载流程

--- a/crates/hustsync-worker/src/hooks/exec.rs
+++ b/crates/hustsync-worker/src/hooks/exec.rs
@@ -1,18 +1,18 @@
 //! `exec_on_success` / `exec_on_failure` hook.
 //!
 //! Runs each configured shell command via `sh -c` with a standardised
-//! env block matching Go `worker/exec_post_hook.go` verbatim
-//! (`TUNASYNC_*`) plus the `HUSTSYNC_*` synonyms. Non-zero exit from
-//! one command is logged but does not abort the list; the next command
-//! still runs.
+//! env block using canonical `HUSTSYNC_*` variables plus legacy
+//! `TUNASYNC_*` aliases with the same values. Non-zero exit from one
+//! command is logged but does not abort the list; the next command still runs.
 //!
-//! Invariant: `TUNASYNC_JOB_EXIT_STATUS` is the literal string
-//! `"success"` on the success hook and `"failure"` on the fail hook —
-//! do NOT change these spellings, operator scripts depend on them.
+//! Invariant: `HUSTSYNC_JOB_EXIT_STATUS` and its legacy
+//! `TUNASYNC_JOB_EXIT_STATUS` alias are the literal strings `"success"` on the
+//! success hook and `"failure"` on the fail hook. Do NOT change these spellings.
 
 use std::time::Duration;
 
 use async_trait::async_trait;
+use std::collections::HashMap;
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -21,6 +21,15 @@ use super::{HookCtx, HookError, JobHook};
 /// Hard-coded 30s per-command budget. Operator-tunable timeouts and
 /// per-status overrides are future extensions.
 const EXEC_TIMEOUT: Duration = Duration::from_secs(30);
+
+const HOOK_ENV_SUFFIXES: &[&str] = &[
+    "MIRROR_NAME",
+    "WORKING_DIR",
+    "UPSTREAM_URL",
+    "LOG_DIR",
+    "LOG_FILE",
+    "JOB_EXIT_STATUS",
+];
 
 pub struct ExecPostHook {
     pub on_success: Vec<String>,
@@ -102,22 +111,62 @@ fn build_env(ctx: &HookCtx, phase: &str) -> Vec<(String, String)> {
         ("LOG_DIR", ctx.log_dir.to_string_lossy().into_owned()),
         ("LOG_FILE", ctx.log_file.to_string_lossy().into_owned()),
     ];
-    let mut env = Vec::with_capacity(pairs.len() * 2 + 2);
+    let mut env = HashMap::new();
     for (key, val) in pairs {
-        let hustsync_val = val.clone();
-        env.push((format!("TUNASYNC_{key}"), val));
-        env.push((format!("HUSTSYNC_{key}"), hustsync_val));
+        set_sync_env_pair(&mut env, key, val);
     }
     if !status.is_empty() {
-        env.push(("TUNASYNC_JOB_EXIT_STATUS".to_string(), status.to_string()));
-        env.push(("HUSTSYNC_JOB_EXIT_STATUS".to_string(), status.to_string()));
+        set_sync_env_pair(&mut env, "JOB_EXIT_STATUS", status.to_string());
     }
     // Propagate any hook-injected env from upstream (e.g. loglimit's
-    // updated log_file). Later entries override earlier.
-    for (k, v) in &ctx.env {
-        env.push((k.clone(), v.clone()));
+    // updated log_file). Later entries override earlier; HUSTSYNC_* wins if a
+    // legacy TUNASYNC_* alias conflicts with it.
+    apply_env_layer(&mut env, &ctx.env);
+    env.into_iter().collect()
+}
+
+fn sync_env_keys(suffix: &str) -> (String, String) {
+    (format!("HUSTSYNC_{suffix}"), format!("TUNASYNC_{suffix}"))
+}
+
+fn set_sync_env_pair(env: &mut HashMap<String, String>, suffix: &str, value: String) {
+    let (canonical, legacy) = sync_env_keys(suffix);
+    env.insert(canonical, value.clone());
+    env.insert(legacy, value);
+}
+
+fn known_sync_suffix(key: &str) -> Option<&'static str> {
+    let suffix = key
+        .strip_prefix("HUSTSYNC_")
+        .or_else(|| key.strip_prefix("TUNASYNC_"))?;
+    HOOK_ENV_SUFFIXES
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == suffix)
+}
+
+fn apply_env_layer(env: &mut HashMap<String, String>, layer: &HashMap<String, String>) {
+    for (key, value) in layer {
+        if known_sync_suffix(key).is_none() {
+            env.insert(key.clone(), value.clone());
+        }
     }
-    env
+
+    for suffix in HOOK_ENV_SUFFIXES {
+        let (canonical, legacy) = sync_env_keys(suffix);
+        match (layer.get(&canonical), layer.get(&legacy)) {
+            (Some(canonical_value), Some(legacy_value)) => {
+                if canonical_value != legacy_value {
+                    tracing::warn!("conflicting {canonical}/{legacy}; using canonical {canonical}");
+                }
+                set_sync_env_pair(env, suffix, canonical_value.clone());
+            }
+            (Some(value), None) | (None, Some(value)) => {
+                set_sync_env_pair(env, suffix, value.clone());
+            }
+            (None, None) => {}
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/hustsync-worker/src/hooks/loglimit.rs
+++ b/crates/hustsync-worker/src/hooks/loglimit.rs
@@ -161,9 +161,10 @@ impl JobHook for LogLimitHook {
         self.point_symlink(&new_file, &self.latest_symlink(ctx))
             .await?;
         // Surface the log_file to subsequent hooks / provider env.
+        // HUSTSYNC_LOG_FILE is canonical; TUNASYNC_LOG_FILE is a legacy alias.
         let as_str = new_file.to_string_lossy().into_owned();
-        ctx.env.insert("TUNASYNC_LOG_FILE".into(), as_str.clone());
-        ctx.env.insert("HUSTSYNC_LOG_FILE".into(), as_str);
+        ctx.env.insert("HUSTSYNC_LOG_FILE".into(), as_str.clone());
+        ctx.env.insert("TUNASYNC_LOG_FILE".into(), as_str);
 
         Ok(())
     }

--- a/crates/hustsync-worker/src/lib.rs
+++ b/crates/hustsync-worker/src/lib.rs
@@ -88,21 +88,18 @@ fn format_manager_url(base: &str, path: &str) -> String {
     )
 }
 
-/// Records the names of mirrors that differ between the running jobs map
-/// and a freshly-loaded config slice. Names that appear only in the old
-/// map are `removed`; names only in the new config are `added`; names in
-/// both are `modified` (the actor is torn down and rebuilt so the new
-/// provider takes effect).
+/// Records the names of mirrors that differ between the current mirror
+/// config snapshot and a freshly-loaded config slice. Names that appear
+/// only in the old snapshot are `removed`; names only in the new config are
+/// `added`; names in both are `modified` only when their full config differs,
+/// matching Go's `reflect.DeepEqual`-based hot-reload diff.
 struct MirrorDiff {
     added: Vec<String>,
     removed: Vec<String>,
     modified: Vec<String>,
 }
 
-fn choose_exec_list(
-    mirror_list: Option<&[String]>,
-    global_list: Option<&[String]>,
-) -> Vec<String> {
+fn choose_exec_list(mirror_list: Option<&[String]>, global_list: Option<&[String]>) -> Vec<String> {
     if let Some(list) = mirror_list
         && !list.is_empty()
     {
@@ -142,34 +139,28 @@ fn resolve_exec_commands(
     (on_success, on_failure)
 }
 
-/// Compare the set of currently-running jobs against a new config slice.
-///
-/// Because `MirrorJob` does not retain its originating `MirrorConfig`, a
-/// deep-equal comparison is not possible without storing extra state. The
-/// caller rebuilds the actor for every name that appears in both sets —
-/// identical to Go's behaviour for the modify path.
+/// Compare the current mirror config snapshot against a new config slice.
 fn diff_mirror_configs(
-    old: &HashMap<String, MirrorJob>,
+    old: &HashMap<String, hustsync_config_parser::MirrorConfig>,
     new_cfg: &[hustsync_config_parser::MirrorConfig],
 ) -> MirrorDiff {
-    let new_names: std::collections::HashSet<&str> = new_cfg
+    let new_by_name: HashMap<&str, &hustsync_config_parser::MirrorConfig> = new_cfg
         .iter()
-        .filter_map(|m| m.name.as_deref())
+        .filter_map(|m| m.name.as_deref().map(|name| (name, m)))
         .collect();
 
     let mut removed = Vec::new();
     let mut modified = Vec::new();
 
-    for name in old.keys() {
-        if new_names.contains(name.as_str()) {
-            modified.push(name.clone());
-        } else {
-            removed.push(name.clone());
+    for (name, old_cfg) in old {
+        match new_by_name.get(name.as_str()) {
+            Some(new_cfg) if *new_cfg != old_cfg => modified.push(name.clone()),
+            Some(_) => {}
+            None => removed.push(name.clone()),
         }
     }
 
-    let old_names: std::collections::HashSet<&str> =
-        old.keys().map(|s| s.as_str()).collect();
+    let old_names: std::collections::HashSet<&str> = old.keys().map(|s| s.as_str()).collect();
 
     let added: Vec<String> = new_cfg
         .iter()
@@ -188,6 +179,7 @@ fn diff_mirror_configs(
 pub struct Worker {
     pub cfg: Arc<WorkerConfig>,
     pub jobs: Arc<RwLock<HashMap<String, MirrorJob>>>,
+    mirror_configs: Arc<RwLock<HashMap<String, hustsync_config_parser::MirrorConfig>>>,
     pub job_handles: Mutex<JoinSet<()>>,
 
     pub manager_tx: mpsc::Sender<JobMessage>,
@@ -230,6 +222,7 @@ impl Worker {
         let exit_token = CancellationToken::new();
 
         let mut jobs_map = HashMap::new();
+        let mut mirror_configs = HashMap::new();
         let mut handles = JoinSet::new();
 
         if let Some(mirrors) = &cfg.mirrors {
@@ -252,6 +245,7 @@ impl Worker {
                         hooks,
                     );
                     jobs_map.insert(name.clone(), job);
+                    mirror_configs.insert(name.clone(), m_cfg.clone());
                     handles.spawn(actor.run());
                 }
             }
@@ -260,6 +254,7 @@ impl Worker {
         let mut worker = Worker {
             cfg: Arc::clone(&cfg),
             jobs: Arc::new(RwLock::new(jobs_map)),
+            mirror_configs: Arc::new(RwLock::new(mirror_configs)),
             job_handles: Mutex::new(handles),
             manager_tx,
             manager_rx: Mutex::new(Some(manager_rx)),
@@ -457,8 +452,7 @@ impl Worker {
             let worker_name = self.name();
 
             for root in api_bases {
-                let url =
-                    format_manager_url(&root, &format!("workers/{}/schedules", worker_name));
+                let url = format_manager_url(&root, &format!("workers/{}/schedules", worker_name));
                 tokio::spawn({
                     let client = client.clone();
                     let url = url.clone();
@@ -774,12 +768,12 @@ impl Worker {
         name: &str,
         m_cfg: &hustsync_config_parser::MirrorConfig,
         initial_state: u32,
-    ) {
+    ) -> bool {
         let provider = match Self::create_provider(name, m_cfg, &self.cfg) {
             Ok(p) => p,
             Err(e) => {
                 tracing::error!("Failed to create provider for {}: {}", name, e);
-                return;
+                return false;
             }
         };
 
@@ -810,12 +804,14 @@ impl Worker {
 
         self.job_handles.lock().await.spawn(actor.run());
         self.jobs.write().await.insert(name.to_owned(), job);
+        true
     }
 
     /// Remove mirrors dropped from the config.
     async fn apply_removed_mirrors(&self, removed: &[String]) {
         for name in removed {
             self.disable_and_remove_job(name).await;
+            self.mirror_configs.write().await.remove(name);
             tracing::info!("Mirror {} removed by config reload", name);
         }
     }
@@ -832,8 +828,13 @@ impl Worker {
                 continue;
             };
             let state = prev.unwrap_or(crate::job::STATE_NONE);
-            self.spawn_mirror_from_cfg(name, m_cfg, state).await;
-            tracing::info!("Mirror {} reloaded by config reload", name);
+            if self.spawn_mirror_from_cfg(name, m_cfg, state).await {
+                self.mirror_configs
+                    .write()
+                    .await
+                    .insert(name.clone(), m_cfg.clone());
+                tracing::info!("Mirror {} reloaded by config reload", name);
+            }
         }
     }
 
@@ -847,9 +848,16 @@ impl Worker {
             let Some(m_cfg) = new_mirrors.iter().find(|m| m.name.as_deref() == Some(name)) else {
                 continue;
             };
-            self.spawn_mirror_from_cfg(name, m_cfg, crate::job::STATE_NONE)
-                .await;
-            tracing::info!("Mirror {} added by config reload", name);
+            if self
+                .spawn_mirror_from_cfg(name, m_cfg, crate::job::STATE_NONE)
+                .await
+            {
+                self.mirror_configs
+                    .write()
+                    .await
+                    .insert(name.clone(), m_cfg.clone());
+                tracing::info!("Mirror {} added by config reload", name);
+            }
         }
     }
 
@@ -867,8 +875,8 @@ impl Worker {
         tracing::info!("Reloading mirror configs");
 
         let diff = {
-            let jobs = self.jobs.read().await;
-            diff_mirror_configs(&jobs, &new_mirrors)
+            let old_configs = self.mirror_configs.read().await;
+            diff_mirror_configs(&old_configs, &new_mirrors)
         };
 
         self.apply_removed_mirrors(&diff.removed).await;
@@ -903,6 +911,7 @@ impl Worker {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::atomic::AtomicU32;
     use std::time::Duration;
@@ -919,7 +928,10 @@ mod tests {
     use tokio::time::{Instant, sleep};
 
     use super::job::{CtrlAction, STATE_NONE};
-    use super::{JobMessage, MirrorJob, Worker, resolve_api_bases, resolve_exec_commands};
+    use super::{
+        JobMessage, MirrorJob, Worker, diff_mirror_configs, resolve_api_bases,
+        resolve_exec_commands,
+    };
 
     type RequestLog = Arc<Mutex<Vec<String>>>;
 
@@ -998,11 +1010,27 @@ mod tests {
         (job, rx)
     }
 
+    fn command_mirror(name: &str, command: &str) -> MirrorConfig {
+        MirrorConfig {
+            name: Some(name.to_string()),
+            provider: Some("command".to_string()),
+            command: Some(command.to_string()),
+            ..MirrorConfig::default()
+        }
+    }
+
+    fn worker_with_mirrors(mirrors: Vec<MirrorConfig>) -> WorkerConfig {
+        WorkerConfig {
+            manager: None,
+            mirrors: Some(mirrors),
+            ..WorkerConfig::default()
+        }
+    }
+
     fn make_cfg(api_base: Option<&str>, api_base_list: Option<Vec<&str>>) -> WorkerManagerConfig {
         WorkerManagerConfig {
             api_base: api_base.map(String::from),
-            api_base_list: api_base_list
-                .map(|v| v.into_iter().map(String::from).collect()),
+            api_base_list: api_base_list.map(|v| v.into_iter().map(String::from).collect()),
             token: None,
             ca_cert: None,
         }
@@ -1044,6 +1072,85 @@ mod tests {
         let cfg = make_cfg(Some("http://manager:14242"), None);
         let bases = resolve_api_bases(&cfg);
         assert_eq!(bases, vec!["http://manager:14242"]);
+    }
+
+    #[test]
+    fn diff_mirror_configs_unchanged_same_name_is_not_modified() {
+        let mirror = command_mirror("archlinux", "true");
+        let old = HashMap::from([("archlinux".to_string(), mirror.clone())]);
+
+        let diff = diff_mirror_configs(&old, &[mirror]);
+
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+        assert!(diff.modified.is_empty());
+    }
+
+    #[test]
+    fn diff_mirror_configs_only_marks_changed_same_name_modified() {
+        let old_mirror = command_mirror("archlinux", "true");
+        let new_mirror = command_mirror("archlinux", "false");
+        let old = HashMap::from([("archlinux".to_string(), old_mirror)]);
+
+        let diff = diff_mirror_configs(&old, &[new_mirror]);
+
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+        assert_eq!(diff.modified, vec!["archlinux"]);
+    }
+
+    #[test]
+    fn diff_mirror_configs_reports_added_and_removed() {
+        let old = HashMap::from([("old".to_string(), command_mirror("old", "true"))]);
+        let new_mirror = command_mirror("new", "true");
+
+        let diff = diff_mirror_configs(&old, &[new_mirror]);
+
+        assert_eq!(diff.added, vec!["new"]);
+        assert_eq!(diff.removed, vec!["old"]);
+        assert!(diff.modified.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reload_unchanged_mirror_keeps_existing_job() {
+        let mirror = command_mirror("archlinux", "true");
+        let worker = Worker::new(worker_with_mirrors(vec![mirror.clone()]));
+        let before_state = {
+            let jobs = worker.jobs.read().await;
+            Arc::clone(&jobs.get("archlinux").unwrap().state)
+        };
+
+        worker.reload_mirror_config(vec![mirror]).await;
+
+        let after_state = {
+            let jobs = worker.jobs.read().await;
+            Arc::clone(&jobs.get("archlinux").unwrap().state)
+        };
+        assert!(Arc::ptr_eq(&before_state, &after_state));
+
+        worker.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn reload_changed_mirror_rebuilds_existing_job() {
+        let mirror = command_mirror("archlinux", "true");
+        let worker = Worker::new(worker_with_mirrors(vec![mirror]));
+        let before_state = {
+            let jobs = worker.jobs.read().await;
+            Arc::clone(&jobs.get("archlinux").unwrap().state)
+        };
+
+        worker
+            .reload_mirror_config(vec![command_mirror("archlinux", "false")])
+            .await;
+
+        let after_state = {
+            let jobs = worker.jobs.read().await;
+            Arc::clone(&jobs.get("archlinux").unwrap().state)
+        };
+        assert!(!Arc::ptr_eq(&before_state, &after_state));
+
+        worker.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/hustsync-worker/src/lib.rs
+++ b/crates/hustsync-worker/src/lib.rs
@@ -397,10 +397,9 @@ impl Worker {
 
         for root in resolve_api_bases(manager_cfg) {
             let url = format_manager_url(&root, "workers");
-            if try_register(client, &url, &msg).await {
-                break;
+            if !try_register(client, &url, &msg).await {
+                tracing::warn!("Failed to register to manager after retries: {}", url);
             }
-            tracing::warn!("Failed to register to manager after retries: {}", url);
         }
     }
 
@@ -639,7 +638,7 @@ impl Worker {
 
                 let api_bases = resolve_api_bases(manager_cfg);
 
-                // Status push: broadcast, break on first success.
+                // Status push: broadcast to every configured manager.
                 let mut status_sent = false;
                 for root in &api_bases {
                     let url = format_manager_url(
@@ -649,12 +648,9 @@ impl Worker {
                     match client.post(&url).json(&smsg).send().await {
                         Ok(resp) if resp.status().is_success() => {
                             status_sent = true;
-                            break;
                         }
                         Ok(resp) => {
-                            tracing::warn!(
-                                "Status push to {} returned {}", url, resp.status()
-                            );
+                            tracing::warn!("Status push to {} returned {}", url, resp.status());
                         }
                         Err(e) => {
                             tracing::warn!("Status push to {} failed: {}", url, e);
@@ -662,9 +658,7 @@ impl Worker {
                     }
                 }
                 if !status_sent {
-                    tracing::error!(
-                        "Failed to push status for {} to all managers", msg.name
-                    );
+                    tracing::error!("Failed to push status for {} to any manager", msg.name);
                 }
 
                 if msg.schedule {
@@ -687,22 +681,17 @@ impl Worker {
                     .collect();
                 let sched_msg = hustsync_internal::msg::MirrorSchedules { schedules: s };
 
-                // Schedule push: broadcast, break on first success.
+                // Schedule push: broadcast to every configured manager.
                 let mut sched_sent = false;
                 for root in &api_bases {
-                    let url = format_manager_url(
-                        root,
-                        &format!("workers/{}/schedules", worker_name),
-                    );
+                    let url =
+                        format_manager_url(root, &format!("workers/{}/schedules", worker_name));
                     match client.post(&url).json(&sched_msg).send().await {
                         Ok(resp) if resp.status().is_success() => {
                             sched_sent = true;
-                            break;
                         }
                         Ok(resp) => {
-                            tracing::warn!(
-                                "Schedule push to {} returned {}", url, resp.status()
-                            );
+                            tracing::warn!("Schedule push to {} returned {}", url, resp.status());
                         }
                         Err(e) => {
                             tracing::warn!("Schedule push to {} failed: {}", url, e);
@@ -710,7 +699,7 @@ impl Worker {
                     }
                 }
                 if !sched_sent {
-                    tracing::error!("Failed to push schedule to all managers");
+                    tracing::error!("Failed to push schedule to any manager");
                 }
             }
         });
@@ -914,12 +903,100 @@ impl Worker {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU32;
+    use std::time::Duration;
+
+    use axum::extract::State;
+    use axum::http::{StatusCode, Uri};
+    use axum::routing::any;
     use hustsync_config_parser::{
         ExecOnStatus, ExecOnStatusExtra, MirrorConfig, WorkerConfig, WorkerGlobalConfig,
-        WorkerManagerConfig,
+        WorkerManagerConfig, WorkerServerConfig,
     };
+    use hustsync_internal::status::SyncStatus;
+    use tokio::sync::{Mutex, mpsc};
+    use tokio::time::{Instant, sleep};
 
-    use super::{resolve_api_bases, resolve_exec_commands};
+    use super::job::{CtrlAction, STATE_NONE};
+    use super::{JobMessage, MirrorJob, Worker, resolve_api_bases, resolve_exec_commands};
+
+    type RequestLog = Arc<Mutex<Vec<String>>>;
+
+    async fn record_path(State(log): State<RequestLog>, uri: Uri) -> StatusCode {
+        log.lock().await.push(uri.path().to_string());
+        StatusCode::OK
+    }
+
+    async fn spawn_recording_manager() -> (String, RequestLog, tokio::task::JoinHandle<()>) {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = axum::Router::new()
+            .fallback(any(record_path))
+            .with_state(Arc::clone(&log));
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        (format!("http://{}", addr), log, handle)
+    }
+
+    async fn wait_for_paths(log: &RequestLog, expected: &[&str]) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let seen = log.lock().await.clone();
+            if expected
+                .iter()
+                .all(|path| seen.iter().any(|got| got == path))
+            {
+                return;
+            }
+
+            if Instant::now() >= deadline {
+                panic!("timed out waiting for paths {:?}; saw {:?}", expected, seen);
+            }
+
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    fn worker_config_with_managers(manager_urls: Vec<String>) -> WorkerConfig {
+        WorkerConfig {
+            global: Some(WorkerGlobalConfig {
+                name: Some("broadcast-worker".to_string()),
+                ..WorkerGlobalConfig::default()
+            }),
+            manager: Some(WorkerManagerConfig {
+                api_base: None,
+                api_base_list: Some(manager_urls),
+                token: Some("token".to_string()),
+                ca_cert: Some("".to_string()),
+            }),
+            server: Some(WorkerServerConfig {
+                hostname: Some("localhost".to_string()),
+                listen_addr: Some("127.0.0.1".to_string()),
+                listen_port: Some(6000),
+                ssl_cert: Some("".to_string()),
+                ssl_key: Some("".to_string()),
+            }),
+            mirrors: None,
+            ..WorkerConfig::default()
+        }
+    }
+
+    fn make_mirror_job(name: &str) -> (MirrorJob, mpsc::Receiver<CtrlAction>) {
+        let (tx, rx) = mpsc::channel(32);
+        let job = MirrorJob {
+            name: name.into(),
+            tx,
+            state: Arc::new(AtomicU32::new(STATE_NONE)),
+            disabled: Arc::new(tokio::sync::Notify::new()),
+            interval: tokio::time::Duration::from_secs(60),
+        };
+        (job, rx)
+    }
 
     fn make_cfg(api_base: Option<&str>, api_base_list: Option<Vec<&str>>) -> WorkerManagerConfig {
         WorkerManagerConfig {
@@ -967,6 +1044,60 @@ mod tests {
         let cfg = make_cfg(Some("http://manager:14242"), None);
         let bases = resolve_api_bases(&cfg);
         assert_eq!(bases, vec!["http://manager:14242"]);
+    }
+
+    #[tokio::test]
+    async fn register_worker_broadcasts_to_all_manager_bases() {
+        let (manager_a, log_a, handle_a) = spawn_recording_manager().await;
+        let (manager_b, log_b, handle_b) = spawn_recording_manager().await;
+        let worker = Worker::new(worker_config_with_managers(vec![manager_a, manager_b]));
+
+        worker.register_worker().await;
+
+        wait_for_paths(&log_a, &["/workers"]).await;
+        wait_for_paths(&log_b, &["/workers"]).await;
+
+        handle_a.abort();
+        handle_b.abort();
+    }
+
+    #[tokio::test]
+    async fn relay_broadcasts_status_and_schedule_to_all_manager_bases() {
+        let (manager_a, log_a, handle_a) = spawn_recording_manager().await;
+        let (manager_b, log_b, handle_b) = spawn_recording_manager().await;
+        let worker = Worker::new(worker_config_with_managers(vec![manager_a, manager_b]));
+
+        let (job, _rx) = make_mirror_job("archlinux");
+        worker
+            .jobs
+            .write()
+            .await
+            .insert("archlinux".to_string(), job);
+        worker.start_message_relay().await;
+
+        worker
+            .manager_tx
+            .send(JobMessage {
+                status: SyncStatus::Success,
+                name: "archlinux".to_string(),
+                msg: String::new(),
+                schedule: true,
+                upstream: "rsync://mirror.example/archlinux/".to_string(),
+                size: Some("1".to_string()),
+                is_master: true,
+            })
+            .await
+            .unwrap();
+
+        let expected = [
+            "/workers/broadcast-worker/jobs/archlinux",
+            "/workers/broadcast-worker/schedules",
+        ];
+        wait_for_paths(&log_a, &expected).await;
+        wait_for_paths(&log_b, &expected).await;
+
+        handle_a.abort();
+        handle_b.abort();
     }
 
     fn strings(items: &[&str]) -> Vec<String> {

--- a/crates/hustsync-worker/src/lib.rs
+++ b/crates/hustsync-worker/src/lib.rs
@@ -24,6 +24,8 @@ pub use job::{CtrlAction, MirrorJob};
 use provider::MirrorProvider;
 use schedule::ScheduleQueue;
 
+const DEFAULT_MANAGER_API_BASE: &str = "http://localhost:14242";
+
 pub struct JobMessage {
     pub status: SyncStatus,
     pub name: String,
@@ -51,7 +53,7 @@ fn resolve_api_bases(cfg: &hustsync_config_parser::WorkerManagerConfig) -> Vec<S
     }
     cfg.api_base
         .as_deref()
-        .unwrap_or("http://localhost:12345")
+        .unwrap_or(DEFAULT_MANAGER_API_BASE)
         .split(',')
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -95,6 +97,49 @@ struct MirrorDiff {
     added: Vec<String>,
     removed: Vec<String>,
     modified: Vec<String>,
+}
+
+fn choose_exec_list(
+    mirror_list: Option<&[String]>,
+    global_list: Option<&[String]>,
+) -> Vec<String> {
+    if let Some(list) = mirror_list
+        && !list.is_empty()
+    {
+        return list.to_vec();
+    }
+    global_list.map(<[String]>::to_vec).unwrap_or_default()
+}
+
+fn resolve_exec_commands(
+    m_cfg: &hustsync_config_parser::MirrorConfig,
+    g_cfg: &WorkerConfig,
+) -> (Vec<String>, Vec<String>) {
+    let mirror_status = m_cfg.exec_on_status.as_ref();
+    let global_status = g_cfg
+        .global
+        .as_ref()
+        .and_then(|g| g.exec_on_status.as_ref());
+
+    let mut on_success = choose_exec_list(
+        mirror_status.and_then(|s| s.exec_on_success.as_deref()),
+        global_status.and_then(|s| s.exec_on_success.as_deref()),
+    );
+    let mut on_failure = choose_exec_list(
+        mirror_status.and_then(|s| s.exec_on_failure.as_deref()),
+        global_status.and_then(|s| s.exec_on_failure.as_deref()),
+    );
+
+    if let Some(extra) = &m_cfg.exec_on_status_extra {
+        if let Some(list) = &extra.exec_on_success_extra {
+            on_success.extend(list.iter().cloned());
+        }
+        if let Some(list) = &extra.exec_on_failure_extra {
+            on_failure.extend(list.iter().cloned());
+        }
+    }
+
+    (on_success, on_failure)
 }
 
 /// Compare the set of currently-running jobs against a new config slice.
@@ -246,7 +291,7 @@ impl Worker {
         let root = api_bases
             .first()
             .map(|s| s.as_str())
-            .unwrap_or("http://localhost:12345");
+            .unwrap_or(DEFAULT_MANAGER_API_BASE);
         let url = format_manager_url(root, &format!("workers/{}/jobs", self.name()));
 
         match hustsync_internal::util::get_json::<Vec<hustsync_internal::msg::MirrorStatus>>(
@@ -275,7 +320,7 @@ impl Worker {
     /// runs in this vec order, `post_*` in reverse (LIFO).
     fn build_hooks(
         m_cfg: &hustsync_config_parser::MirrorConfig,
-        _g_cfg: &WorkerConfig,
+        g_cfg: &WorkerConfig,
     ) -> Vec<Arc<dyn hooks::JobHook>> {
         let mut chain: Vec<Arc<dyn hooks::JobHook>> = Vec::new();
         // 1. Built-in: ensure working_dir exists before anything else.
@@ -287,24 +332,7 @@ impl Worker {
         // 3. User-configured exec_on_{success,failure}. `exec_on_status_extra`
         //    (mirror-level additions to global defaults) is appended after
         //    the base list, matching Go's "append extra to the end".
-        let mut on_success: Vec<String> = Vec::new();
-        let mut on_failure: Vec<String> = Vec::new();
-        if let Some(status) = &m_cfg.exec_on_status {
-            if let Some(list) = &status.exec_on_success {
-                on_success.extend(list.iter().cloned());
-            }
-            if let Some(list) = &status.exec_on_failure {
-                on_failure.extend(list.iter().cloned());
-            }
-        }
-        if let Some(extra) = &m_cfg.exec_on_status_extra {
-            if let Some(list) = &extra.exec_on_success_extra {
-                on_success.extend(list.iter().cloned());
-            }
-            if let Some(list) = &extra.exec_on_failure_extra {
-                on_failure.extend(list.iter().cloned());
-            }
-        }
+        let (on_success, on_failure) = resolve_exec_commands(m_cfg, g_cfg);
         if !on_success.is_empty() || !on_failure.is_empty() {
             chain.push(Arc::new(hooks::ExecPostHook::new(on_success, on_failure)));
         }
@@ -886,9 +914,12 @@ impl Worker {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
-    use hustsync_config_parser::WorkerManagerConfig;
+    use hustsync_config_parser::{
+        ExecOnStatus, ExecOnStatusExtra, MirrorConfig, WorkerConfig, WorkerGlobalConfig,
+        WorkerManagerConfig,
+    };
 
-    use super::resolve_api_bases;
+    use super::{resolve_api_bases, resolve_exec_commands};
 
     fn make_cfg(api_base: Option<&str>, api_base_list: Option<Vec<&str>>) -> WorkerManagerConfig {
         WorkerManagerConfig {
@@ -928,7 +959,7 @@ mod tests {
     fn resolve_defaults_when_both_absent() {
         let cfg = make_cfg(None, None);
         let bases = resolve_api_bases(&cfg);
-        assert_eq!(bases, vec!["http://localhost:12345"]);
+        assert_eq!(bases, vec!["http://localhost:14242"]);
     }
 
     #[test]
@@ -936,5 +967,95 @@ mod tests {
         let cfg = make_cfg(Some("http://manager:14242"), None);
         let bases = resolve_api_bases(&cfg);
         assert_eq!(bases, vec!["http://manager:14242"]);
+    }
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn worker_with_global(success: &[&str], failure: &[&str]) -> WorkerConfig {
+        WorkerConfig {
+            global: Some(WorkerGlobalConfig {
+                exec_on_status: Some(ExecOnStatus {
+                    exec_on_success: Some(strings(success)),
+                    exec_on_failure: Some(strings(failure)),
+                }),
+                ..WorkerGlobalConfig::default()
+            }),
+            ..WorkerConfig::default()
+        }
+    }
+
+    fn mirror_with_exec(
+        success: Option<&[&str]>,
+        failure: Option<&[&str]>,
+        success_extra: Option<&[&str]>,
+        failure_extra: Option<&[&str]>,
+    ) -> MirrorConfig {
+        MirrorConfig {
+            exec_on_status: Some(ExecOnStatus {
+                exec_on_success: success.map(strings),
+                exec_on_failure: failure.map(strings),
+            }),
+            exec_on_status_extra: Some(ExecOnStatusExtra {
+                exec_on_success_extra: success_extra.map(strings),
+                exec_on_failure_extra: failure_extra.map(strings),
+            }),
+            ..MirrorConfig::default()
+        }
+    }
+
+    #[test]
+    fn exec_commands_fall_back_to_global_when_mirror_unset() {
+        let worker = worker_with_global(&["global-success"], &["global-failure"]);
+        let mirror = mirror_with_exec(None, None, None, None);
+
+        let (success, failure) = resolve_exec_commands(&mirror, &worker);
+
+        assert_eq!(success, strings(&["global-success"]));
+        assert_eq!(failure, strings(&["global-failure"]));
+    }
+
+    #[test]
+    fn exec_commands_mirror_non_empty_list_overrides_global() {
+        let worker = worker_with_global(&["global-success"], &["global-failure"]);
+        let mirror = mirror_with_exec(
+            Some(&["mirror-success"]),
+            Some(&["mirror-failure"]),
+            None,
+            None,
+        );
+
+        let (success, failure) = resolve_exec_commands(&mirror, &worker);
+
+        assert_eq!(success, strings(&["mirror-success"]));
+        assert_eq!(failure, strings(&["mirror-failure"]));
+    }
+
+    #[test]
+    fn exec_commands_empty_mirror_list_falls_back_to_global() {
+        let worker = worker_with_global(&["global-success"], &["global-failure"]);
+        let mirror = mirror_with_exec(Some(&[]), Some(&[]), None, None);
+
+        let (success, failure) = resolve_exec_commands(&mirror, &worker);
+
+        assert_eq!(success, strings(&["global-success"]));
+        assert_eq!(failure, strings(&["global-failure"]));
+    }
+
+    #[test]
+    fn exec_commands_extra_appends_after_selected_base() {
+        let worker = worker_with_global(&["global-success"], &["global-failure"]);
+        let mirror = mirror_with_exec(
+            Some(&["mirror-success"]),
+            None,
+            Some(&["extra-success"]),
+            Some(&["extra-failure"]),
+        );
+
+        let (success, failure) = resolve_exec_commands(&mirror, &worker);
+
+        assert_eq!(success, strings(&["mirror-success", "extra-success"]));
+        assert_eq!(failure, strings(&["global-failure", "extra-failure"]));
     }
 }

--- a/crates/hustsync-worker/src/provider/cmd_provider.rs
+++ b/crates/hustsync-worker/src/provider/cmd_provider.rs
@@ -118,14 +118,6 @@ impl MirrorProvider for CmdProvider {
             cmd.process_group(0);
         }
 
-        // Inject both TUNASYNC_* (Go parity for existing mirror scripts) and
-        // HUSTSYNC_* (Rust-port canonical names).  Both sets must stay in sync.
-        cmd.env("TUNASYNC_MIRROR_NAME", &self.config.common.name)
-            .env("TUNASYNC_WORKING_DIR", &self.config.common.working_dir)
-            .env("TUNASYNC_UPSTREAM_URL", &self.config.common.upstream_url)
-            .env("TUNASYNC_LOG_DIR", &self.config.common.log_dir)
-            .env("TUNASYNC_LOG_FILE", &effective_log_file);
-
         inject_provider_env(&mut cmd, &self.config.common, &effective_log_file, &ctx.env);
 
         tracing::info!("Starting command provider for {}", self.config.common.name);
@@ -163,8 +155,13 @@ impl MirrorProvider for CmdProvider {
                 } else {
                     let code = status.code().unwrap_or(-1);
                     let msg = format!("Command exited with status: {}", status);
-                    log_provider_failure("Cmd", &self.config.common.name, &msg, &effective_log_file)
-                        .await;
+                    log_provider_failure(
+                        "Cmd",
+                        &self.config.common.name,
+                        &msg,
+                        &effective_log_file,
+                    )
+                    .await;
                     Err(ProviderError::Execution { code, msg })
                 }
             }

--- a/crates/hustsync-worker/src/provider/mod.rs
+++ b/crates/hustsync-worker/src/provider/mod.rs
@@ -136,32 +136,92 @@ pub(crate) async fn terminate_pgid(pgid: &AtomicU32, name: &str) {
     }
 }
 
-/// Inject the standard TUNASYNC_* and HUSTSYNC_* environment variables into `cmd`.
+const PROVIDER_ENV_SUFFIXES: &[&str] = &[
+    "MIRROR_NAME",
+    "WORKING_DIR",
+    "UPSTREAM_URL",
+    "LOG_DIR",
+    "LOG_FILE",
+];
+
+fn sync_env_keys(suffix: &str) -> (String, String) {
+    (format!("HUSTSYNC_{suffix}"), format!("TUNASYNC_{suffix}"))
+}
+
+fn set_sync_env_pair(env: &mut HashMap<String, String>, suffix: &str, value: String) {
+    let (canonical, legacy) = sync_env_keys(suffix);
+    env.insert(canonical, value.clone());
+    env.insert(legacy, value);
+}
+
+fn known_sync_suffix<'a>(key: &str, suffixes: &'a [&str]) -> Option<&'a str> {
+    let suffix = key
+        .strip_prefix("HUSTSYNC_")
+        .or_else(|| key.strip_prefix("TUNASYNC_"))?;
+    suffixes
+        .iter()
+        .copied()
+        .find(|candidate| *candidate == suffix)
+}
+
+fn apply_env_layer(
+    env: &mut HashMap<String, String>,
+    layer: &HashMap<String, String>,
+    suffixes: &[&str],
+) {
+    for (key, value) in layer {
+        if known_sync_suffix(key, suffixes).is_none() {
+            env.insert(key.clone(), value.clone());
+        }
+    }
+
+    for suffix in suffixes {
+        let (canonical, legacy) = sync_env_keys(suffix);
+        match (layer.get(&canonical), layer.get(&legacy)) {
+            (Some(canonical_value), Some(legacy_value)) => {
+                if canonical_value != legacy_value {
+                    tracing::warn!("conflicting {canonical}/{legacy}; using canonical {canonical}");
+                }
+                set_sync_env_pair(env, suffix, canonical_value.clone());
+            }
+            (Some(value), None) | (None, Some(value)) => {
+                set_sync_env_pair(env, suffix, value.clone());
+            }
+            (None, None) => {}
+        }
+    }
+}
+
+/// Inject the standard HUSTSYNC_* environment variables into `cmd`, plus
+/// TUNASYNC_* legacy aliases with the same values.
 ///
 /// Called after any provider-specific credentials (USER, RSYNC_PASSWORD) have
 /// already been set, so those are not overwritten here. Hook-injected variables
 /// from `ctx_env` are layered on top so they win over the config defaults.
+/// Within a HUSTSYNC_/TUNASYNC_ pair, HUSTSYNC_* is canonical and wins when
+/// both prefixes are present with different values.
 pub(crate) fn inject_provider_env(
     cmd: &mut tokio::process::Command,
     common: &CommonProviderConfig,
     effective_log_file: &str,
     ctx_env: &HashMap<String, String>,
 ) {
-    cmd.env("TUNASYNC_MIRROR_NAME", &common.name)
-        .env("TUNASYNC_WORKING_DIR", &common.working_dir)
-        .env("TUNASYNC_UPSTREAM_URL", &common.upstream_url)
-        .env("TUNASYNC_LOG_DIR", &common.log_dir)
-        .env("TUNASYNC_LOG_FILE", effective_log_file)
-        .env("HUSTSYNC_MIRROR_NAME", &common.name)
-        .env("HUSTSYNC_WORKING_DIR", &common.working_dir)
-        .env("HUSTSYNC_UPSTREAM_URL", &common.upstream_url)
-        .env("HUSTSYNC_LOG_DIR", &common.log_dir)
-        .env("HUSTSYNC_LOG_FILE", effective_log_file);
-    for (k, v) in &common.env {
-        cmd.env(k, v);
+    let mut env = HashMap::new();
+    for (suffix, value) in [
+        ("MIRROR_NAME", common.name.clone()),
+        ("WORKING_DIR", common.working_dir.clone()),
+        ("UPSTREAM_URL", common.upstream_url.clone()),
+        ("LOG_DIR", common.log_dir.clone()),
+        ("LOG_FILE", effective_log_file.to_string()),
+    ] {
+        set_sync_env_pair(&mut env, suffix, value);
     }
-    for (k, v) in ctx_env {
-        cmd.env(k, v);
+
+    apply_env_layer(&mut env, &common.env, PROVIDER_ENV_SUFFIXES);
+    apply_env_layer(&mut env, ctx_env, PROVIDER_ENV_SUFFIXES);
+
+    for (key, value) in env {
+        cmd.env(key, value);
     }
 }
 
@@ -172,10 +232,21 @@ pub(crate) fn inject_provider_env(
 /// key is present it takes precedence; otherwise the provider's
 /// configured default is used.
 pub(crate) fn resolve_log_file(ctx: &RunContext, default: &str) -> String {
-    ctx.env
-        .get("TUNASYNC_LOG_FILE")
-        .cloned()
-        .unwrap_or_else(|| default.to_string())
+    match (
+        ctx.env.get("HUSTSYNC_LOG_FILE"),
+        ctx.env.get("TUNASYNC_LOG_FILE"),
+    ) {
+        (Some(canonical), Some(legacy)) => {
+            if canonical != legacy {
+                tracing::warn!(
+                    "conflicting HUSTSYNC_LOG_FILE/TUNASYNC_LOG_FILE; using HUSTSYNC_LOG_FILE"
+                );
+            }
+            canonical.clone()
+        }
+        (Some(value), None) | (None, Some(value)) => value.clone(),
+        (None, None) => default.to_string(),
+    }
 }
 
 /// Store the total transfer size parsed from an rsync log file.
@@ -184,12 +255,8 @@ pub(crate) fn resolve_log_file(ctx: &RunContext, default: &str) -> String {
 /// non-empty. A parse failure (malformed or absent stats block) is
 /// silently treated as "no size available" — callers use this for
 /// informational reporting only, never for control flow.
-pub(crate) async fn store_rsync_data_size(
-    data_size: &Mutex<Option<String>>,
-    log_file: &str,
-) {
-    let size =
-        hustsync_internal::util::extract_size_from_rsync_log(log_file).unwrap_or_default();
+pub(crate) async fn store_rsync_data_size(data_size: &Mutex<Option<String>>, log_file: &str) {
+    let size = hustsync_internal::util::extract_size_from_rsync_log(log_file).unwrap_or_default();
     if !size.is_empty() {
         *data_size.lock().await = Some(size);
     }
@@ -322,8 +389,9 @@ pub(crate) async fn run_child_with_cancellation(
 /// loop runs outside provider.Run().
 ///
 /// `env` contains hook-injected variables (e.g. the rotated
-/// `TUNASYNC_LOG_FILE` from the loglimit hook). Providers layer it on
-/// top of their standard env vars so hook overrides win.
+/// `HUSTSYNC_LOG_FILE` from the loglimit hook). Providers layer it on
+/// top of their standard env vars so hook overrides win; TUNASYNC_* aliases
+/// are accepted as fallback but HUSTSYNC_* wins on conflict.
 #[derive(Debug, Clone, Default)]
 pub struct RunContext {
     pub cancel: CancellationToken,
@@ -483,8 +551,8 @@ pub fn build_provider(
 
         let is_rsync_provider = matches!(p_type, "rsync" | "two-stage-rsync");
         if is_rsync_provider {
-            if let Some(grc) = global
-                .and_then(|g| g.dangerous_global_rsync_success_exit_codes.as_ref())
+            if let Some(grc) =
+                global.and_then(|g| g.dangerous_global_rsync_success_exit_codes.as_ref())
             {
                 codes.extend(grc);
             }

--- a/crates/hustsync-worker/src/provider/mod.rs
+++ b/crates/hustsync-worker/src/provider/mod.rs
@@ -136,7 +136,7 @@ pub(crate) async fn terminate_pgid(pgid: &AtomicU32, name: &str) {
     }
 }
 
-/// Inject the standard HUSTSYNC_* environment variables into `cmd`.
+/// Inject the standard TUNASYNC_* and HUSTSYNC_* environment variables into `cmd`.
 ///
 /// Called after any provider-specific credentials (USER, RSYNC_PASSWORD) have
 /// already been set, so those are not overwritten here. Hook-injected variables
@@ -147,7 +147,12 @@ pub(crate) fn inject_provider_env(
     effective_log_file: &str,
     ctx_env: &HashMap<String, String>,
 ) {
-    cmd.env("HUSTSYNC_MIRROR_NAME", &common.name)
+    cmd.env("TUNASYNC_MIRROR_NAME", &common.name)
+        .env("TUNASYNC_WORKING_DIR", &common.working_dir)
+        .env("TUNASYNC_UPSTREAM_URL", &common.upstream_url)
+        .env("TUNASYNC_LOG_DIR", &common.log_dir)
+        .env("TUNASYNC_LOG_FILE", effective_log_file)
+        .env("HUSTSYNC_MIRROR_NAME", &common.name)
         .env("HUSTSYNC_WORKING_DIR", &common.working_dir)
         .env("HUSTSYNC_UPSTREAM_URL", &common.upstream_url)
         .env("HUSTSYNC_LOG_DIR", &common.log_dir)

--- a/crates/hustsync-worker/src/server.rs
+++ b/crates/hustsync-worker/src/server.rs
@@ -86,12 +86,19 @@ async fn handle_cmd(
             CmdVerb::Restart => crate::job::CtrlAction::Restart,
             CmdVerb::Stop => {
                 if job.state() == crate::job::STATE_DISABLED {
-                    return (StatusCode::OK, Json(json!({"msg": "Job is disabled"})));
+                    return (StatusCode::OK, Json(json!({"msg": "OK"})));
                 }
                 crate::job::CtrlAction::Stop
             }
-            CmdVerb::Disable => crate::job::CtrlAction::Disable,
-            CmdVerb::Ping => crate::job::CtrlAction::Ping,
+            CmdVerb::Disable => {
+                if job.state() == crate::job::STATE_DISABLED {
+                    return (StatusCode::OK, Json(json!({"msg": "OK"})));
+                }
+                crate::job::CtrlAction::Disable
+            }
+            CmdVerb::Ping => {
+                return (StatusCode::OK, Json(json!({"msg": "OK"})));
+            }
             _ => {
                 return (
                     StatusCode::NOT_ACCEPTABLE,
@@ -101,16 +108,27 @@ async fn handle_cmd(
         }
     };
 
-    // Re-borrow jobs for the ctrl dispatch; the earlier guard is gone.
-    let jobs = state.jobs.read().await;
-    let Some(job) = jobs.get(&cmd.mirror_id) else {
-        return (
-            StatusCode::OK,
-            Json(
-                json!({"msg": format!("Mirror '{}' is not configured on this worker", cmd.mirror_id)}),
-            ),
-        );
+    // Re-borrow and clone the job for ctrl dispatch; the earlier guard is gone.
+    let job = {
+        let jobs = state.jobs.read().await;
+        let Some(job) = jobs.get(&cmd.mirror_id) else {
+            return (
+                StatusCode::OK,
+                Json(
+                    json!({"msg": format!("Mirror '{}' is not configured on this worker", cmd.mirror_id)}),
+                ),
+            );
+        };
+        job.clone()
     };
+
+    let disabled = if action == crate::job::CtrlAction::Disable {
+        Some(Arc::clone(&job.disabled))
+    } else {
+        None
+    };
+
+    let disabled_notified = disabled.as_ref().map(|disabled| disabled.notified());
 
     if let Err(e) = job.send_ctrl(action).await {
         tracing::error!("Failed to send action to job {}: {}", cmd.mirror_id, e);
@@ -118,6 +136,10 @@ async fn handle_cmd(
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"msg": "Internal server error"})),
         );
+    }
+
+    if let Some(disabled_notified) = disabled_notified {
+        disabled_notified.await;
     }
 
     (StatusCode::OK, Json(json!({"msg": "OK"})))

--- a/crates/hustsync-worker/tests/cmd_provider_contract.rs
+++ b/crates/hustsync-worker/tests/cmd_provider_contract.rs
@@ -16,7 +16,9 @@ mod cmd_provider_contract {
     use std::time::Duration;
 
     use hustsync_worker::provider::cmd_provider::{CmdProvider, CmdProviderConfig};
-    use hustsync_worker::provider::{CommonProviderConfig, MirrorProvider, ProviderError, RunContext};
+    use hustsync_worker::provider::{
+        CommonProviderConfig, MirrorProvider, ProviderError, RunContext,
+    };
     use tempfile::tempdir;
     use tokio_util::sync::CancellationToken;
 
@@ -29,6 +31,26 @@ mod cmd_provider_contract {
         fail_on_match: Option<String>,
         size_pattern: Option<String>,
     ) -> CmdProvider {
+        make_provider_with_env(
+            dir,
+            name,
+            command,
+            timeout,
+            fail_on_match,
+            size_pattern,
+            HashMap::new(),
+        )
+    }
+
+    fn make_provider_with_env(
+        dir: &tempfile::TempDir,
+        name: &str,
+        command: &str,
+        timeout: Duration,
+        fail_on_match: Option<String>,
+        size_pattern: Option<String>,
+        env: HashMap<String, String>,
+    ) -> CmdProvider {
         let log_file = dir.path().join("run.log");
         let cfg = CmdProviderConfig {
             common: CommonProviderConfig {
@@ -40,7 +62,7 @@ mod cmd_provider_contract {
                 interval: Duration::from_secs(3600),
                 retry: 1,
                 timeout,
-                env: HashMap::new(),
+                env,
                 is_master: true,
                 success_exit_codes: vec![],
             },
@@ -51,51 +73,11 @@ mod cmd_provider_contract {
         CmdProvider::new(cfg).unwrap()
     }
 
-    // ── 1. TUNASYNC_* env injection ──────────────────────────────────────────
+    // ── 1. HUSTSYNC_* env injection ──────────────────────────────────────────
 
-    /// All five TUNASYNC_* variables must be present in the child's env.
-    /// A `sh -c 'env | grep TUNASYNC_'` command writes them to the log file;
-    /// we count distinct TUNASYNC_-prefixed lines.
-    #[tokio::test]
-    async fn tunasync_env_vars_are_injected() {
-        let dir = tempdir().unwrap();
-        let provider = make_provider(
-            &dir,
-            "test-mirror",
-            "sh -c 'env | grep TUNASYNC_'",
-            Duration::ZERO,
-            None,
-            None,
-        );
-
-        provider.run(RunContext::default()).await.unwrap();
-
-        let log = tokio::fs::read_to_string(provider.log_file())
-            .await
-            .unwrap();
-        let tunasync_count = log.lines().filter(|l| l.starts_with("TUNASYNC_")).count();
-
-        assert!(
-            tunasync_count >= 5,
-            "expected ≥5 TUNASYNC_* lines, got {tunasync_count}; log:\n{log}"
-        );
-
-        // Verify the exact Go-compat variable names.
-        for var in &[
-            "TUNASYNC_MIRROR_NAME",
-            "TUNASYNC_WORKING_DIR",
-            "TUNASYNC_UPSTREAM_URL",
-            "TUNASYNC_LOG_DIR",
-            "TUNASYNC_LOG_FILE",
-        ] {
-            assert!(log.contains(var), "missing env var {var} in log:\n{log}");
-        }
-    }
-
-    // ── 2. HUSTSYNC_* dual-prefix injection ──────────────────────────────────
-
-    /// The five HUSTSYNC_* synonyms must also be
-    /// set so that scripts written for hustsync.rs do not need a TUNASYNC_ shim.
+    /// All five canonical HUSTSYNC_* variables must be present in the child env.
+    /// TUNASYNC_* remains a legacy alias, but HUSTSYNC_* is the primary
+    /// contract new scripts should depend on.
     #[tokio::test]
     async fn hustsync_env_vars_are_injected() {
         let dir = tempdir().unwrap();
@@ -129,6 +111,102 @@ mod cmd_provider_contract {
         ] {
             assert!(log.contains(var), "missing env var {var} in log:\n{log}");
         }
+    }
+
+    // ── 2. legacy alias sync / conflict handling ─────────────────────────────
+
+    /// Legacy TUNASYNC_* aliases are still exported, but they mirror the
+    /// canonical HUSTSYNC_* value so scripts do not see conflicting data.
+    #[tokio::test]
+    async fn tunasync_legacy_aliases_mirror_canonical_values() {
+        let dir = tempdir().unwrap();
+        let provider = make_provider(
+            &dir,
+            "test-mirror",
+            "sh -c 'printf \"%s\\n\" \"$HUSTSYNC_MIRROR_NAME|$TUNASYNC_MIRROR_NAME\" \"$HUSTSYNC_WORKING_DIR|$TUNASYNC_WORKING_DIR\" \"$HUSTSYNC_UPSTREAM_URL|$TUNASYNC_UPSTREAM_URL\" \"$HUSTSYNC_LOG_DIR|$TUNASYNC_LOG_DIR\" \"$HUSTSYNC_LOG_FILE|$TUNASYNC_LOG_FILE\"'",
+            Duration::ZERO,
+            None,
+            None,
+        );
+
+        provider.run(RunContext::default()).await.unwrap();
+
+        let log = tokio::fs::read_to_string(provider.log_file())
+            .await
+            .unwrap();
+
+        for line in log.lines() {
+            let (canonical, legacy) = line.split_once('|').unwrap();
+            assert_eq!(
+                canonical, legacy,
+                "legacy alias must mirror canonical: {line}"
+            );
+        }
+    }
+
+    /// If both prefixes are configured for the same semantic field, HUSTSYNC_*
+    /// wins and both exported names are normalised to that value.
+    #[tokio::test]
+    async fn hustsync_env_wins_when_prefixes_conflict() {
+        let dir = tempdir().unwrap();
+        let mut env = HashMap::new();
+        env.insert("HUSTSYNC_UPSTREAM_URL".into(), "canonical".into());
+        env.insert("TUNASYNC_UPSTREAM_URL".into(), "legacy".into());
+        let provider = make_provider_with_env(
+            &dir,
+            "test-mirror",
+            "sh -c 'printf \"%s\\n\" \"$HUSTSYNC_UPSTREAM_URL\" \"$TUNASYNC_UPSTREAM_URL\"'",
+            Duration::ZERO,
+            None,
+            None,
+            env,
+        );
+
+        provider.run(RunContext::default()).await.unwrap();
+
+        let log = tokio::fs::read_to_string(provider.log_file())
+            .await
+            .unwrap();
+        let lines: Vec<_> = log.lines().collect();
+        assert_eq!(lines, vec!["canonical", "canonical"]);
+    }
+
+    /// Runtime hook env is layered after config env. A HUSTSYNC_LOG_FILE /
+    /// TUNASYNC_LOG_FILE conflict must choose HUSTSYNC_LOG_FILE for both the
+    /// actual log path and the child process env.
+    #[tokio::test]
+    async fn hustsync_log_file_wins_over_legacy_log_file_conflict() {
+        let dir = tempdir().unwrap();
+        let canonical_log = dir.path().join("canonical.log");
+        let legacy_log = dir.path().join("legacy.log");
+        let provider = make_provider(
+            &dir,
+            "test-mirror",
+            "sh -c 'printf \"%s\\n\" \"$HUSTSYNC_LOG_FILE\" \"$TUNASYNC_LOG_FILE\"'",
+            Duration::ZERO,
+            None,
+            None,
+        );
+        let mut ctx = RunContext::default();
+        ctx.env.insert(
+            "HUSTSYNC_LOG_FILE".into(),
+            canonical_log.to_string_lossy().into_owned(),
+        );
+        ctx.env.insert(
+            "TUNASYNC_LOG_FILE".into(),
+            legacy_log.to_string_lossy().into_owned(),
+        );
+
+        provider.run(ctx).await.unwrap();
+
+        let log = tokio::fs::read_to_string(&canonical_log).await.unwrap();
+        let lines: Vec<_> = log.lines().collect();
+        let canonical = canonical_log.to_string_lossy();
+        assert_eq!(lines, vec![canonical.as_ref(), canonical.as_ref()]);
+        assert!(
+            !legacy_log.exists(),
+            "legacy log path must not be used when canonical path is present"
+        );
     }
 
     // ── 3. fail_on_match ─────────────────────────────────────────────────────

--- a/crates/hustsync-worker/tests/contract_cmd.rs
+++ b/crates/hustsync-worker/tests/contract_cmd.rs
@@ -23,8 +23,8 @@ mod contract_cmd {
     use chrono::{Duration as ChronoDuration, Utc};
     use http_body_util::BodyExt as _;
     use hustsync_internal::msg::{CmdVerb, WorkerCmd};
-    use hustsync_worker::job::{CtrlAction, STATE_DISABLED};
     use hustsync_worker::MirrorJob;
+    use hustsync_worker::job::{CtrlAction, STATE_DISABLED};
     use hustsync_worker::schedule::ScheduleQueue;
     use hustsync_worker::server::{AppState, make_http_server};
     use serde_json::Value;
@@ -157,9 +157,7 @@ mod contract_cmd {
 
     async fn expect_no_action(rx: &mut mpsc::Receiver<CtrlAction>) {
         assert!(
-            timeout(Duration::from_millis(50), rx.recv())
-                .await
-                .is_err(),
+            timeout(Duration::from_millis(50), rx.recv()).await.is_err(),
             "command must not send a ctrl action"
         );
     }
@@ -172,6 +170,25 @@ mod contract_cmd {
         let (state, _rx) = state_with_job("archlinux");
 
         let (status, body) = post_cmd(state, worker_cmd("archlinux", CmdVerb::Start)).await;
+
+        assert_eq!(status, 200);
+        assert_eq!(body["msg"], "OK");
+    }
+
+    /// Go's manager can encode omitted command payloads as JSON null. The Rust
+    /// worker must treat those as empty collections instead of rejecting the
+    /// request at Axum's JSON extractor boundary.
+    #[tokio::test]
+    async fn test_valid_cmd_accepts_null_args_and_options() {
+        let (state, _rx) = state_with_job("archlinux");
+        let body = serde_json::json!({
+            "options": null,
+            "args": null,
+            "mirror_id": "archlinux",
+            "cmd": "ping"
+        });
+
+        let (status, body) = post_cmd(state, body).await;
 
         assert_eq!(status, 200);
         assert_eq!(body["msg"], "OK");
@@ -208,11 +225,8 @@ mod contract_cmd {
         let (state, mut rx) = state_with_job("archlinux");
         schedule_job(&state, "archlinux").await;
 
-        let (status, body) = post_cmd(
-            Arc::clone(&state),
-            worker_cmd("archlinux", CmdVerb::Stop),
-        )
-        .await;
+        let (status, body) =
+            post_cmd(Arc::clone(&state), worker_cmd("archlinux", CmdVerb::Stop)).await;
 
         assert_eq!(status, 200);
         assert_eq!(body["msg"], "OK");
@@ -231,11 +245,8 @@ mod contract_cmd {
         }
         schedule_job(&state, "archlinux").await;
 
-        let (status, body) = post_cmd(
-            Arc::clone(&state),
-            worker_cmd("archlinux", CmdVerb::Stop),
-        )
-        .await;
+        let (status, body) =
+            post_cmd(Arc::clone(&state), worker_cmd("archlinux", CmdVerb::Stop)).await;
 
         assert_eq!(status, 200);
         assert_eq!(body["msg"], "OK");
@@ -333,11 +344,8 @@ mod contract_cmd {
         let (state, mut rx) = state_with_job("archlinux");
         schedule_job(&state, "archlinux").await;
 
-        let (status, body) = post_cmd(
-            Arc::clone(&state),
-            worker_cmd("archlinux", CmdVerb::Ping),
-        )
-        .await;
+        let (status, body) =
+            post_cmd(Arc::clone(&state), worker_cmd("archlinux", CmdVerb::Ping)).await;
 
         assert_eq!(status, 200);
         assert_eq!(body["msg"], "OK");

--- a/crates/hustsync-worker/tests/contract_cmd.rs
+++ b/crates/hustsync-worker/tests/contract_cmd.rs
@@ -20,8 +20,10 @@ mod contract_cmd {
     use std::sync::Arc;
     use std::sync::atomic::AtomicU32;
 
+    use chrono::{Duration as ChronoDuration, Utc};
     use http_body_util::BodyExt as _;
     use hustsync_internal::msg::{CmdVerb, WorkerCmd};
+    use hustsync_worker::job::{CtrlAction, STATE_DISABLED};
     use hustsync_worker::MirrorJob;
     use hustsync_worker::schedule::ScheduleQueue;
     use hustsync_worker::server::{AppState, make_http_server};
@@ -107,6 +109,61 @@ mod contract_cmd {
         .unwrap()
     }
 
+    async fn schedule_job(state: &Arc<AppState>, name: &str) {
+        let job = state
+            .jobs
+            .read()
+            .await
+            .get(name)
+            .expect("job must exist")
+            .clone();
+        state
+            .schedule_queue
+            .lock()
+            .await
+            .add_job(Utc::now() + ChronoDuration::minutes(5), job);
+        assert!(
+            state
+                .schedule_queue
+                .lock()
+                .await
+                .get_jobs()
+                .iter()
+                .any(|job| job.job_name == name),
+            "test setup must schedule {name}"
+        );
+    }
+
+    async fn assert_schedule_flushed(state: &Arc<AppState>, name: &str) {
+        assert!(
+            !state
+                .schedule_queue
+                .lock()
+                .await
+                .get_jobs()
+                .iter()
+                .any(|job| job.job_name == name),
+            "{name} must be removed from the schedule queue"
+        );
+    }
+
+    async fn expect_action(rx: &mut mpsc::Receiver<CtrlAction>, expected: CtrlAction) {
+        let got = timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .expect("timed out waiting for ctrl action")
+            .expect("ctrl channel closed before expected action");
+        assert_eq!(got, expected);
+    }
+
+    async fn expect_no_action(rx: &mut mpsc::Receiver<CtrlAction>) {
+        assert!(
+            timeout(Duration::from_millis(50), rx.recv())
+                .await
+                .is_err(),
+            "command must not send a ctrl action"
+        );
+    }
+
     // ── tests ─────────────────────────────────────────────────────────────────
 
     /// Configured mirror + valid verb → 200 {"msg": "OK"}
@@ -143,6 +200,149 @@ mod contract_cmd {
 
         assert_eq!(status, 406);
         assert_eq!(body["msg"], "Invalid Command");
+    }
+
+    /// Stop on an active/non-disabled mirror flushes schedule and sends Stop.
+    #[tokio::test]
+    async fn test_stop_known_mirror_flushes_schedule_and_sends_stop() {
+        let (state, mut rx) = state_with_job("archlinux");
+        schedule_job(&state, "archlinux").await;
+
+        let (status, body) = post_cmd(
+            Arc::clone(&state),
+            worker_cmd("archlinux", CmdVerb::Stop),
+        )
+        .await;
+
+        assert_eq!(status, 200);
+        assert_eq!(body["msg"], "OK");
+        assert_schedule_flushed(&state, "archlinux").await;
+        expect_action(&mut rx, CtrlAction::Stop).await;
+    }
+
+    /// Stop on a disabled mirror still returns Go's fixed OK body and does
+    /// not send an action because no Go job goroutine would be receiving it.
+    #[tokio::test]
+    async fn test_stop_disabled_mirror_returns_ok_without_action() {
+        let (state, mut rx) = state_with_job("archlinux");
+        {
+            let jobs = state.jobs.read().await;
+            jobs.get("archlinux").unwrap().set_state(STATE_DISABLED);
+        }
+        schedule_job(&state, "archlinux").await;
+
+        let (status, body) = post_cmd(
+            Arc::clone(&state),
+            worker_cmd("archlinux", CmdVerb::Stop),
+        )
+        .await;
+
+        assert_eq!(status, 200);
+        assert_eq!(body["msg"], "OK");
+        assert_schedule_flushed(&state, "archlinux").await;
+        expect_no_action(&mut rx).await;
+    }
+
+    /// Disable flushes any pending schedule, dispatches Disable to the job,
+    /// and waits for the job's disabled notification before returning.
+    #[tokio::test]
+    async fn test_disable_known_mirror_flushes_schedule_sends_disable_and_waits() {
+        let (state, mut rx) = state_with_job("archlinux");
+        let disabled = {
+            let jobs = state.jobs.read().await;
+            Arc::clone(&jobs.get("archlinux").unwrap().disabled)
+        };
+        schedule_job(&state, "archlinux").await;
+
+        let mut post = tokio::spawn(post_cmd(
+            Arc::clone(&state),
+            worker_cmd("archlinux", CmdVerb::Disable),
+        ));
+
+        let got = timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .expect("timed out waiting for Disable action")
+            .expect("ctrl channel closed before Disable action");
+        assert_eq!(got, CtrlAction::Disable);
+
+        assert!(
+            timeout(Duration::from_millis(50), &mut post).await.is_err(),
+            "disable response must wait for the disabled notification"
+        );
+
+        disabled.notify_waiters();
+
+        let (status, body) = post.await.unwrap();
+
+        assert_eq!(status, 200);
+        assert_eq!(body["msg"], "OK");
+        assert_schedule_flushed(&state, "archlinux").await;
+    }
+
+    /// Disable on an already-disabled mirror is a Go-compatible no-op after
+    /// schedule flush: it returns OK and does not send another Disable action.
+    #[tokio::test]
+    async fn test_disable_disabled_mirror_returns_ok_without_action() {
+        let (state, mut rx) = state_with_job("archlinux");
+        {
+            let jobs = state.jobs.read().await;
+            jobs.get("archlinux").unwrap().set_state(STATE_DISABLED);
+        }
+        schedule_job(&state, "archlinux").await;
+
+        let (status, body) = post_cmd(
+            Arc::clone(&state),
+            worker_cmd("archlinux", CmdVerb::Disable),
+        )
+        .await;
+
+        assert_eq!(status, 200);
+        assert_eq!(body["msg"], "OK");
+        assert_schedule_flushed(&state, "archlinux").await;
+        expect_no_action(&mut rx).await;
+    }
+
+    /// Restart flushes any pending schedule and dispatches Restart. Go starts
+    /// a disabled job goroutine before sending this action; Rust's actor stays
+    /// alive and accepts the same Restart action while disabled.
+    #[tokio::test]
+    async fn test_restart_disabled_mirror_flushes_schedule_and_sends_restart() {
+        let (state, mut rx) = state_with_job("archlinux");
+        {
+            let jobs = state.jobs.read().await;
+            jobs.get("archlinux").unwrap().set_state(STATE_DISABLED);
+        }
+        schedule_job(&state, "archlinux").await;
+
+        let (status, body) = post_cmd(
+            Arc::clone(&state),
+            worker_cmd("archlinux", CmdVerb::Restart),
+        )
+        .await;
+
+        assert_eq!(status, 200);
+        assert_eq!(body["msg"], "OK");
+        assert_schedule_flushed(&state, "archlinux").await;
+        expect_action(&mut rx, CtrlAction::Restart).await;
+    }
+
+    /// Ping is Go-compatible no-op bookkeeping: it flushes schedule and
+    /// returns OK without sending anything to the job control channel.
+    #[tokio::test]
+    async fn test_ping_known_mirror_flushes_schedule_without_action() {
+        let (state, mut rx) = state_with_job("archlinux");
+        schedule_job(&state, "archlinux").await;
+
+        let (status, body) = post_cmd(
+            Arc::clone(&state),
+            worker_cmd("archlinux", CmdVerb::Ping),
+        )
+        .await;
+
+        assert_eq!(status, 200);
+        assert_eq!(body["msg"], "OK");
+        assert_schedule_flushed(&state, "archlinux").await;
+        expect_no_action(&mut rx).await;
     }
 
     /// Worker-level Reload (empty mirror_id) → 200 {"msg": "Reload triggered"}

--- a/crates/hustsync-worker/tests/fixtures/bin/fake_rsync.sh
+++ b/crates/hustsync-worker/tests/fixtures/bin/fake_rsync.sh
@@ -20,6 +20,21 @@ for arg in "$@"; do
     esac
 done
 
+if [[ -n "$FAKE_ENV_DUMP" ]]; then
+    {
+        echo "TUNASYNC_MIRROR_NAME=${TUNASYNC_MIRROR_NAME:-}"
+        echo "TUNASYNC_WORKING_DIR=${TUNASYNC_WORKING_DIR:-}"
+        echo "TUNASYNC_UPSTREAM_URL=${TUNASYNC_UPSTREAM_URL:-}"
+        echo "TUNASYNC_LOG_DIR=${TUNASYNC_LOG_DIR:-}"
+        echo "TUNASYNC_LOG_FILE=${TUNASYNC_LOG_FILE:-}"
+        echo "HUSTSYNC_MIRROR_NAME=${HUSTSYNC_MIRROR_NAME:-}"
+        echo "HUSTSYNC_WORKING_DIR=${HUSTSYNC_WORKING_DIR:-}"
+        echo "HUSTSYNC_UPSTREAM_URL=${HUSTSYNC_UPSTREAM_URL:-}"
+        echo "HUSTSYNC_LOG_DIR=${HUSTSYNC_LOG_DIR:-}"
+        echo "HUSTSYNC_LOG_FILE=${HUSTSYNC_LOG_FILE:-}"
+    } >> "$FAKE_ENV_DUMP"
+fi
+
 if [[ -n "$FAKE_SLEEP" ]]; then
     sleep "$FAKE_SLEEP" &
     sleep_pid=$!

--- a/crates/hustsync-worker/tests/hooks_exec_contract.rs
+++ b/crates/hustsync-worker/tests/hooks_exec_contract.rs
@@ -36,14 +36,14 @@ fn marker(dir: &TempDir, name: &str) -> PathBuf {
 }
 
 #[tokio::test]
-async fn post_success_runs_each_command_with_tunasync_env() {
+async fn post_success_runs_each_command_with_canonical_env_and_legacy_alias() {
     let tmp = TempDir::new().unwrap();
     let marker_a = marker(&tmp, "a.marker");
     let marker_b = marker(&tmp, "b.marker");
     let hook = ExecPostHook::new(
         vec![
             format!(
-                "echo \"$TUNASYNC_MIRROR_NAME|$TUNASYNC_JOB_EXIT_STATUS\" > {}",
+                "echo \"$HUSTSYNC_MIRROR_NAME|$TUNASYNC_MIRROR_NAME|$HUSTSYNC_JOB_EXIT_STATUS|$TUNASYNC_JOB_EXIT_STATUS\" > {}",
                 marker_a.display()
             ),
             format!("echo \"$HUSTSYNC_UPSTREAM_URL\" > {}", marker_b.display()),
@@ -55,9 +55,32 @@ async fn post_success_runs_each_command_with_tunasync_env() {
     hook.post_success(&mut ctx).await.unwrap();
 
     let a = std::fs::read_to_string(&marker_a).unwrap();
-    assert_eq!(a.trim(), "archlinux|success");
+    assert_eq!(a.trim(), "archlinux|archlinux|success|success");
     let b = std::fs::read_to_string(&marker_b).unwrap();
     assert_eq!(b.trim(), "rsync://up.test/m/");
+}
+
+#[tokio::test]
+async fn post_success_prefers_hustsync_env_when_alias_conflicts() {
+    let tmp = TempDir::new().unwrap();
+    let out = marker(&tmp, "env.marker");
+    let hook = ExecPostHook::new(
+        vec![format!(
+            "echo \"$HUSTSYNC_LOG_FILE|$TUNASYNC_LOG_FILE\" > {}",
+            out.display()
+        )],
+        vec![],
+    );
+    let mut ctx = make_ctx(&tmp, "archlinux");
+    ctx.env
+        .insert("HUSTSYNC_LOG_FILE".into(), "canonical.log".into());
+    ctx.env
+        .insert("TUNASYNC_LOG_FILE".into(), "legacy.log".into());
+
+    hook.post_success(&mut ctx).await.unwrap();
+
+    let content = std::fs::read_to_string(out).unwrap();
+    assert_eq!(content.trim(), "canonical.log|canonical.log");
 }
 
 #[tokio::test]

--- a/crates/hustsync-worker/tests/hooks_loglimit_contract.rs
+++ b/crates/hustsync-worker/tests/hooks_loglimit_contract.rs
@@ -50,7 +50,12 @@ async fn pre_exec_creates_fresh_file_and_symlink() {
     let target = std::fs::read_link(&link).unwrap();
     assert_eq!(target, ctx.log_file);
 
-    // The env was surfaced with the new log path.
+    // The env was surfaced with the new log path. HUSTSYNC_LOG_FILE is
+    // canonical; TUNASYNC_LOG_FILE remains a legacy alias with the same value.
+    assert_eq!(
+        ctx.env.get("HUSTSYNC_LOG_FILE").unwrap(),
+        &ctx.log_file.to_string_lossy().to_string()
+    );
     assert_eq!(
         ctx.env.get("TUNASYNC_LOG_FILE").unwrap(),
         &ctx.log_file.to_string_lossy().to_string()

--- a/crates/hustsync-worker/tests/rsync_provider_contract.rs
+++ b/crates/hustsync-worker/tests/rsync_provider_contract.rs
@@ -221,6 +221,72 @@ fn zero_rsync_timeout_falls_back_to_default_not_zero() {
     );
 }
 
+#[tokio::test]
+async fn run_injects_tunasync_and_hustsync_env_vars() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let working_dir = tmp.path().join("work");
+    let log_dir = tmp.path().join("log");
+    let log_file = log_dir.join("run.log");
+    let working_dir_str = working_dir.to_string_lossy().into_owned();
+    let log_dir_str = log_dir.to_string_lossy().into_owned();
+    let log_file_str = log_file.to_string_lossy().into_owned();
+
+    let script = r#"printf '%s\n' \
+"TUNASYNC_MIRROR_NAME=$TUNASYNC_MIRROR_NAME" \
+"TUNASYNC_WORKING_DIR=$TUNASYNC_WORKING_DIR" \
+"TUNASYNC_UPSTREAM_URL=$TUNASYNC_UPSTREAM_URL" \
+"TUNASYNC_LOG_DIR=$TUNASYNC_LOG_DIR" \
+"TUNASYNC_LOG_FILE=$TUNASYNC_LOG_FILE" \
+"HUSTSYNC_MIRROR_NAME=$HUSTSYNC_MIRROR_NAME" \
+"HUSTSYNC_WORKING_DIR=$HUSTSYNC_WORKING_DIR" \
+"HUSTSYNC_UPSTREAM_URL=$HUSTSYNC_UPSTREAM_URL" \
+"HUSTSYNC_LOG_DIR=$HUSTSYNC_LOG_DIR" \
+"HUSTSYNC_LOG_FILE=$HUSTSYNC_LOG_FILE""#;
+
+    let config = RsyncProviderConfig {
+        common: CommonProviderConfig {
+            name: "env-test".to_string(),
+            upstream_url: "rsync://example.com/repo/".to_string(),
+            working_dir: working_dir_str.clone(),
+            log_dir: log_dir_str.clone(),
+            log_file: log_file_str.clone(),
+            interval: Duration::from_secs(3600),
+            retry: 2,
+            timeout: Duration::from_secs(5),
+            env: HashMap::new(),
+            is_master: true,
+            success_exit_codes: vec![],
+        },
+        command: "sh".to_string(),
+        username: None,
+        password: None,
+        exclude_file: None,
+        rsync_options: vec![],
+        global_options: vec![],
+        rsync_override: Some(vec!["-c".to_string(), script.to_string()]),
+        rsync_override_only: true,
+        rsync_no_timeout: false,
+        rsync_timeout: None,
+        use_ipv6: false,
+        use_ipv4: false,
+    };
+
+    let provider = RsyncProvider::new(config).unwrap();
+    provider.run(RunContext::default()).await.unwrap();
+
+    let log = tokio::fs::read_to_string(&log_file).await.unwrap();
+    assert!(log.contains("TUNASYNC_MIRROR_NAME=env-test"));
+    assert!(log.contains(&format!("TUNASYNC_WORKING_DIR={working_dir_str}")));
+    assert!(log.contains("TUNASYNC_UPSTREAM_URL=rsync://example.com/repo/"));
+    assert!(log.contains(&format!("TUNASYNC_LOG_DIR={log_dir_str}")));
+    assert!(log.contains(&format!("TUNASYNC_LOG_FILE={log_file_str}")));
+    assert!(log.contains("HUSTSYNC_MIRROR_NAME=env-test"));
+    assert!(log.contains(&format!("HUSTSYNC_WORKING_DIR={working_dir_str}")));
+    assert!(log.contains("HUSTSYNC_UPSTREAM_URL=rsync://example.com/repo/"));
+    assert!(log.contains(&format!("HUSTSYNC_LOG_DIR={log_dir_str}")));
+    assert!(log.contains(&format!("HUSTSYNC_LOG_FILE={log_file_str}")));
+}
+
 // ---------------------------------------------------------------------------
 // timeout enforcement — provider.run() returns ProviderError::Timeout
 //

--- a/crates/hustsync-worker/tests/rsync_provider_contract.rs
+++ b/crates/hustsync-worker/tests/rsync_provider_contract.rs
@@ -222,7 +222,7 @@ fn zero_rsync_timeout_falls_back_to_default_not_zero() {
 }
 
 #[tokio::test]
-async fn run_injects_tunasync_and_hustsync_env_vars() {
+async fn run_injects_canonical_env_and_legacy_aliases() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let working_dir = tmp.path().join("work");
     let log_dir = tmp.path().join("log");
@@ -275,16 +275,16 @@ async fn run_injects_tunasync_and_hustsync_env_vars() {
     provider.run(RunContext::default()).await.unwrap();
 
     let log = tokio::fs::read_to_string(&log_file).await.unwrap();
-    assert!(log.contains("TUNASYNC_MIRROR_NAME=env-test"));
-    assert!(log.contains(&format!("TUNASYNC_WORKING_DIR={working_dir_str}")));
-    assert!(log.contains("TUNASYNC_UPSTREAM_URL=rsync://example.com/repo/"));
-    assert!(log.contains(&format!("TUNASYNC_LOG_DIR={log_dir_str}")));
-    assert!(log.contains(&format!("TUNASYNC_LOG_FILE={log_file_str}")));
     assert!(log.contains("HUSTSYNC_MIRROR_NAME=env-test"));
     assert!(log.contains(&format!("HUSTSYNC_WORKING_DIR={working_dir_str}")));
     assert!(log.contains("HUSTSYNC_UPSTREAM_URL=rsync://example.com/repo/"));
     assert!(log.contains(&format!("HUSTSYNC_LOG_DIR={log_dir_str}")));
     assert!(log.contains(&format!("HUSTSYNC_LOG_FILE={log_file_str}")));
+    assert!(log.contains("TUNASYNC_MIRROR_NAME=env-test"));
+    assert!(log.contains(&format!("TUNASYNC_WORKING_DIR={working_dir_str}")));
+    assert!(log.contains("TUNASYNC_UPSTREAM_URL=rsync://example.com/repo/"));
+    assert!(log.contains(&format!("TUNASYNC_LOG_DIR={log_dir_str}")));
+    assert!(log.contains(&format!("TUNASYNC_LOG_FILE={log_file_str}")));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/hustsync-worker/tests/two_stage_rsync_contract.rs
+++ b/crates/hustsync-worker/tests/two_stage_rsync_contract.rs
@@ -126,6 +126,40 @@ async fn stage1_success_leads_to_stage2_success() {
 }
 
 #[tokio::test]
+async fn run_injects_tunasync_and_hustsync_env_vars() {
+    let dir = TempDir::new().unwrap();
+    let dump_path = dir.path().join("env-dump.txt");
+    let mut env = HashMap::new();
+    env.insert("FAKE_STAGE1_EXIT".to_string(), "0".to_string());
+    env.insert("FAKE_STAGE2_EXIT".to_string(), "0".to_string());
+    env.insert(
+        "FAKE_ENV_DUMP".to_string(),
+        dump_path.to_string_lossy().into_owned(),
+    );
+
+    let cfg = make_config("m-env", &dir, env);
+    let working_dir = cfg.common.working_dir.clone();
+    let log_dir = cfg.common.log_dir.clone();
+    let log_file = cfg.common.log_file.clone();
+    let upstream = cfg.common.upstream_url.clone();
+
+    let provider = TwoStageRsyncProvider::new(cfg).unwrap();
+    run(&provider).await.expect("both stages must succeed");
+
+    let dump = std::fs::read_to_string(&dump_path).unwrap();
+    assert!(dump.contains("TUNASYNC_MIRROR_NAME=m-env"));
+    assert!(dump.contains(&format!("TUNASYNC_WORKING_DIR={working_dir}")));
+    assert!(dump.contains(&format!("TUNASYNC_UPSTREAM_URL={upstream}")));
+    assert!(dump.contains(&format!("TUNASYNC_LOG_DIR={log_dir}")));
+    assert!(dump.contains(&format!("TUNASYNC_LOG_FILE={log_file}")));
+    assert!(dump.contains("HUSTSYNC_MIRROR_NAME=m-env"));
+    assert!(dump.contains(&format!("HUSTSYNC_WORKING_DIR={working_dir}")));
+    assert!(dump.contains(&format!("HUSTSYNC_UPSTREAM_URL={upstream}")));
+    assert!(dump.contains(&format!("HUSTSYNC_LOG_DIR={log_dir}")));
+    assert!(dump.contains(&format!("HUSTSYNC_LOG_FILE={log_file}")));
+}
+
+#[tokio::test]
 async fn stage2_failure_fails_run() {
     let dir = TempDir::new().unwrap();
     let mut env = HashMap::new();

--- a/crates/hustsync-worker/tests/two_stage_rsync_contract.rs
+++ b/crates/hustsync-worker/tests/two_stage_rsync_contract.rs
@@ -126,7 +126,7 @@ async fn stage1_success_leads_to_stage2_success() {
 }
 
 #[tokio::test]
-async fn run_injects_tunasync_and_hustsync_env_vars() {
+async fn run_injects_canonical_env_and_legacy_aliases() {
     let dir = TempDir::new().unwrap();
     let dump_path = dir.path().join("env-dump.txt");
     let mut env = HashMap::new();
@@ -147,16 +147,16 @@ async fn run_injects_tunasync_and_hustsync_env_vars() {
     run(&provider).await.expect("both stages must succeed");
 
     let dump = std::fs::read_to_string(&dump_path).unwrap();
-    assert!(dump.contains("TUNASYNC_MIRROR_NAME=m-env"));
-    assert!(dump.contains(&format!("TUNASYNC_WORKING_DIR={working_dir}")));
-    assert!(dump.contains(&format!("TUNASYNC_UPSTREAM_URL={upstream}")));
-    assert!(dump.contains(&format!("TUNASYNC_LOG_DIR={log_dir}")));
-    assert!(dump.contains(&format!("TUNASYNC_LOG_FILE={log_file}")));
     assert!(dump.contains("HUSTSYNC_MIRROR_NAME=m-env"));
     assert!(dump.contains(&format!("HUSTSYNC_WORKING_DIR={working_dir}")));
     assert!(dump.contains(&format!("HUSTSYNC_UPSTREAM_URL={upstream}")));
     assert!(dump.contains(&format!("HUSTSYNC_LOG_DIR={log_dir}")));
     assert!(dump.contains(&format!("HUSTSYNC_LOG_FILE={log_file}")));
+    assert!(dump.contains("TUNASYNC_MIRROR_NAME=m-env"));
+    assert!(dump.contains(&format!("TUNASYNC_WORKING_DIR={working_dir}")));
+    assert!(dump.contains(&format!("TUNASYNC_UPSTREAM_URL={upstream}")));
+    assert!(dump.contains(&format!("TUNASYNC_LOG_DIR={log_dir}")));
+    assert!(dump.contains(&format!("TUNASYNC_LOG_FILE={log_file}")));
 }
 
 #[tokio::test]

--- a/crates/hustsync/src/main.rs
+++ b/crates/hustsync/src/main.rs
@@ -196,6 +196,10 @@ fn load_runtime_worker_config(config_path: &std::path::Path) -> Result<WorkerCon
     Ok(config)
 }
 
+fn format_error_chain(err: &anyhow::Error) -> String {
+    format!("{err:#}")
+}
+
 async fn reload_worker_from_path(worker: &Worker, config_path: &std::path::Path) {
     tracing::info!("Reloading worker config from {}", config_path.display());
     match load_runtime_worker_config(config_path) {
@@ -222,7 +226,11 @@ async fn start_worker(worker_args: WorkerArgs) -> Result<()> {
     let config: WorkerConfig = match load_runtime_worker_config(&config_path) {
         Ok(cfg) => cfg,
         Err(err) => {
-            warn!("Error loading worker config from {:?}: {err}.", config_path);
+            warn!(
+                "Error loading worker config from {:?}: {}.",
+                config_path,
+                format_error_chain(&err)
+            );
             std::process::exit(1);
         }
     };
@@ -296,5 +304,22 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Manager(m) => start_manager(m).await.with_context(|| "manager start"),
         Commands::Worker(w) => start_worker(w).await.with_context(|| "worker start"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+
+    #[test]
+    fn format_error_chain_includes_context_and_root_cause() {
+        let err = anyhow!("TOML parse error: unknown field `docker_image`")
+            .context("load worker config from /tmp/worker.toml");
+
+        let msg = format_error_chain(&err);
+
+        assert!(msg.contains("load worker config from /tmp/worker.toml"));
+        assert!(msg.contains("unknown field `docker_image`"));
     }
 }

--- a/docs/example/manager.conf
+++ b/docs/example/manager.conf
@@ -2,7 +2,7 @@ debug = false
 
 [server]
 addr = "127.0.0.1"
-port = 12345
+port = 14242
 ssl_cert = ""
 ssl_key = ""
 

--- a/docs/example/test_manager.toml
+++ b/docs/example/test_manager.toml
@@ -2,7 +2,7 @@ debug = true
 
 [server]
 addr = "127.0.0.1"
-port = 12345
+port = 14242
 ssl_cert = ""
 ssl_key = ""
 

--- a/docs/example/test_worker.toml
+++ b/docs/example/test_worker.toml
@@ -5,7 +5,7 @@ mirror_dir = "/tmp/hustsync_test/mirrors"
 concurrent = 10
 
 [manager]
-api_base = "http://127.0.0.1:12345"
+api_base = "http://127.0.0.1:14242"
 token = "secret"
 ca_cert = ""
 

--- a/docs/example/worker.conf
+++ b/docs/example/worker.conf
@@ -6,7 +6,7 @@ concurrent = 10
 interval = 120
 
 [manager]
-api_base = "http://localhost:12345"
+api_base = "http://localhost:14242"
 token = ""
 ca_cert = ""
 


### PR DESCRIPTION
  - Allow manager startup without an explicit config file
  - Align manager, worker, CLI, and examples on tunasync's 14242 default port
  - Emit TUNASYNC_* alongside HUSTSYNC_* for provider processes
  - Match Go fallback semantics for global exec_on_success/exec_on_failure